### PR TITLE
Do not prefix namespaces that appear within a namespace.

### DIFF
--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -10,12 +10,10 @@ class NamespaceReplacer extends BaseReplacer
     public function replace($contents)
     {
         $searchNamespace = $this->autoloader->getSearchNamespace();
-
         return preg_replace_callback(
-            '/' . addslashes($searchNamespace) . '([\\\|;])/U',
+            '/([^\\?])(' . addslashes($searchNamespace) . '[\\\|;])/U',
             function ($matches) {
-                $replace = trim($matches[0], $matches[1]);
-                return $this->dep_namespace . $replace . $matches[1];
+                return $matches[1] . $this->dep_namespace . $matches[2];
             },
             $contents
         );

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -28,6 +28,23 @@ class NamespaceReplacerTest extends TestCase
         $this->assertEquals('namespace Prefix\\Test\\Test;', $contents);
     }
 
+
+    /** @test */
+    public function it_doesnt_replaces_namespace_inside_namespace() {
+
+        $autoloader = new Psr0();
+        $autoloader->namespace = 'Test';
+
+        $replacer = new NamespaceReplacer();
+        $replacer->setAutoloader($autoloader);
+        $replacer->dep_namespace = 'Prefix\\';
+        $this->replacer = $replacer;
+
+        $contents ="namespace Test\\Something;\n\nuse Test\\Test;";
+        $contents = $this->replacer->replace($contents);
+        $this->assertEquals("namespace Prefix\\Test\\Something;\n\nuse Prefix\\Test\\Test;", $contents);
+    }
+
     /** @test */
     public function it_replaces_partial_namespace_declarations()
     {


### PR DESCRIPTION
I came across this when using with Mozart with Stripe's library. The namespace is `Stripe` and it was prefixing every instance of `Stripe` - even within the namespace. For instance, the `CurlClient.php`:

    <?php

    namespace Stripe\HttpClient;

    use Stripe\Stripe; 
    ...

became:

    <?php

    namespace Prefix\Stripe\HttpClient;

    use Prefix\Stripe\Prefix\Stripe; 
    ...

instead of

    use Prefix\Stripe\Stripe;

I've added a unit-test, and I've tested the fix with the Stripe library and it hasn't had any unintended effects.