### PR TITLE
Support dependency tree of packages

### DIFF
--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -15,6 +15,9 @@ class Package
     /** @var array */
     public $autoloaders = [];
 
+    /** @var array */
+    public $dependencies = [];
+
     public function __construct($path)
     {
         $this->path   = $path;
@@ -46,5 +49,21 @@ class Package
 
             array_push($this->autoloaders, $autoloader);
         }
+    }
+
+    public function findDependencies($vendor_path)
+    {
+        $this->dependencies = array_keys((array)$this->config->require);
+        if (isset($this->config->suggest) && $this->config->suggest) {
+            $this->dependencies = array_unique(
+                array_merge($this->dependencies, array_keys((array)$this->config->suggest))
+            );
+        }
+        $this->dependencies = array_filter(
+            $this->dependencies,
+            function ($dependency) use ($vendor_path) {
+                return file_exists($vendor_path . '/' . $dependency);
+            }
+        );
     }
 }

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -18,6 +18,9 @@ class Package
     /** @var array */
     public $dependencies = [];
 
+    /** @var array */
+    public $suggested_dependencies = [];
+
     public function __construct($path)
     {
         $this->path   = $path;
@@ -51,19 +54,11 @@ class Package
         }
     }
 
-    public function findDependencies($vendor_path)
+    public function findDependencies()
     {
         $this->dependencies = array_keys((array)$this->config->require);
         if (isset($this->config->suggest) && $this->config->suggest) {
-            $this->dependencies = array_unique(
-                array_merge($this->dependencies, array_keys((array)$this->config->suggest))
-            );
+            $this->suggested_dependencies = array_keys((array)$this->config->suggest);
         }
-        $this->dependencies = array_filter(
-            $this->dependencies,
-            function ($dependency) use ($vendor_path) {
-                return file_exists($vendor_path . '/' . $dependency);
-            }
-        );
     }
 }

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -16,10 +16,10 @@ class Compose extends Command
     {
         $this->setName('compose');
         $this->addOption(
-            'with_dependencies',
+            'skip_dependencies',
             null,
             InputOption::VALUE_OPTIONAL,
-            'Process also sub-dependencies.',
+            'Skip processing of package sub-dependencies.',
             false
         );
         $this->setDescription('Composes all dependencies as a package inside a WordPress plugin.');
@@ -28,7 +28,7 @@ class Compose extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $with_dependencies = $input->getOption('with_dependencies') !== false;
+        $skip_dependencies = $input->getOption('skip_dependencies') !== false;
         $workingDir = getcwd();
 
         $config = json_decode(file_get_contents($workingDir . '/composer.json'));
@@ -44,7 +44,7 @@ class Compose extends Command
             $package = new Package($workingDir . '/vendor/' . $package_slug);
             $package->findAutoloaders();
             $mover->movePackage($package);
-            if (!$with_dependencies) {
+            if ($skip_dependencies) {
                 continue;
             }
             $package->findDependencies($workingDir . '/vendor');
@@ -58,7 +58,7 @@ class Compose extends Command
 
         $mover->replaceClassmapNames();
 
-        if (!$with_dependencies) {
+        if ($skip_dependencies) {
             return;
         }
 

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -6,6 +6,7 @@ use CoenJacobs\Mozart\Composer\Package;
 use CoenJacobs\Mozart\Mover;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Compose extends Command
@@ -13,12 +14,20 @@ class Compose extends Command
     protected function configure()
     {
         $this->setName('compose');
+        $this->addOption(
+            'with_dependencies',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Process also sub-dependencies.',
+            false
+        );
         $this->setDescription('Composes all dependencies as a package inside a WordPress plugin.');
         $this->setHelp('');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $with_dependencies = $input->getOption('with_dependencies') !== false;
         $workingDir = getcwd();
 
         $config = json_decode(file_get_contents($workingDir . '/composer.json'));
@@ -27,10 +36,23 @@ class Compose extends Command
         $mover = new Mover($workingDir, $config);
         $mover->deleteTargetDirs();
 
-        foreach ($config->packages as $package_slug) {
+        $packages = new \ArrayIterator($config->packages);
+        $processed_packages = [];
+
+        foreach ($packages as $package_slug) {
             $package = new Package($workingDir . '/vendor/' . $package_slug);
             $package->findAutoloaders();
             $mover->movePackage($package);
+            if (!$with_dependencies) {
+                continue;
+            }
+            $package->findDependencies($workingDir . '/vendor');
+            $processed_packages[] = $package;
+            foreach ($package->dependencies as $dependency) {
+                if (!in_array($dependency, $packages->getArrayCopy())) {
+                    $packages->append($dependency);
+                };
+            }
         }
 
         $mover->replaceClassmapNames();

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -89,7 +89,8 @@ class Mover
      * @param $path
      * @return mixed
      */
-    public function moveFile(Package $package, $autoloader, $file, $path = '')   {
+    public function moveFile(Package $package, $autoloader, $file, $path = '')
+    {
         if ($autoloader instanceof NamespaceAutoloader) {
             $namespacePath = $autoloader->getNamespacePath();
             $replaceWith = $this->config->dep_directory . $namespacePath;

--- a/src/Synchronizer.php
+++ b/src/Synchronizer.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace CoenJacobs\Mozart;
+
+use CoenJacobs\Mozart\Composer\Autoload\Classmap;
+use CoenJacobs\Mozart\Composer\Autoload\NamespaceAutoloader;
+use CoenJacobs\Mozart\Composer\Package;
+use CoenJacobs\Mozart\Replace\ClassmapReplacer;
+use CoenJacobs\Mozart\Replace\NamespaceReplacer;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class Synchronizer
+{
+    /** @var string */
+    protected $workingDir;
+
+    /** @var string */
+    protected $targetDir;
+
+    /** @var \stdClass */
+    protected $config;
+
+    /** @var Filesystem */
+    protected $filesystem;
+
+    public function __construct($workingDir, $config)
+    {
+        $this->workingDir = $workingDir;
+        $this->targetDir = $config->dep_directory;
+        $this->config = $config;
+
+        $this->filesystem = new Filesystem(new Local($this->workingDir));
+    }
+
+
+    public function syncMovedPackageWithDependency(Package $package, Package $dependency)
+    {
+        $finder = new Finder();
+
+        foreach ($package->autoloaders as $autoloader) {
+            if ($autoloader instanceof NamespaceAutoloader) {
+                $source_path = $this->workingDir . $this->targetDir . $autoloader->getNamespacePath();
+                $finder->files()->in($source_path);
+
+                foreach ($finder as $file) {
+                    if ('.php' == substr($file, '-4', 4)) {
+                        foreach ($dependency->autoloaders as $dep_autoloader) {
+                            $targetFile = str_replace($this->workingDir, '', $file->getRealPath());
+                            $this->replaceInFile($targetFile, $dep_autoloader);
+                        }
+                    }
+                }
+            }
+
+            if ($autoloader instanceof Classmap) {
+                $finder = new Finder();
+                $source_path = $this->workingDir . $this->config->classmap_directory . $package->config->name;
+                $finder->files()->in($source_path);
+
+                foreach ($finder as $foundFile) {
+                    if ('.php' == substr($foundFile, '-4', 4)) {
+                        foreach ($dependency->autoloaders as $dep_autoloader) {
+                            $targetFile = str_replace($this->workingDir, '', $foundFile->getRealPath());
+                            $this->replaceInFile($targetFile, $dep_autoloader);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+    * @param $targetFile
+    * @param $autoloader
+    */
+    public function replaceInFile($targetFile, $autoloader)
+    {
+        $contents = $this->filesystem->read($targetFile);
+
+        if ($autoloader instanceof NamespaceAutoloader) {
+            $replacer = new NamespaceReplacer();
+            $replacer->dep_namespace = $this->config->dep_namespace;
+        } else {
+            $replacer = new ClassmapReplacer();
+            $replacer->classmap_prefix = $this->config->classmap_prefix;
+        }
+
+        $replacer->setAutoloader($autoloader);
+        $contents = $replacer->replace($contents);
+
+        $this->filesystem->put($targetFile, $contents);
+    }
+}


### PR DESCRIPTION
~~I've added an option`--with_dependencies`  for the compose command. When the command runs without the option it does nothing to sub-deps and it works same as current version.~~

When the command runs it process all installed sub-dependencies of a package (required and suggested) as if they were listed in mozart config. ([commit](https://github.com/coenjacobs/mozart/commit/ab0af7b21443a96ea74aafa85a8da34828279943))

After moving all dependencies it replaces sub-dependency namespaces or classnames within parent dependency package. ([commit](https://github.com/coenjacobs/mozart/commit/9ce5b142ca28afddada5bf8ffd7da9da31a5a757))

Closes #1 