### PR TITLE
Full dependency tree rewrite

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,5 +3,6 @@
 <ruleset name="mozart">
     <description>Coding standard ruleset based on the PSR-2 coding standard.</description>
     <rule ref="PSR2"/>
-    <file>./src/</file>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
 </ruleset>

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -15,6 +15,9 @@ class Package
     /** @var array */
     public $autoloaders = [];
 
+    /** @var array */
+    public $dependencies = [];
+
     public function __construct($path)
     {
         $this->path   = $path;

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -50,7 +50,7 @@ class Compose extends Command
         $this->replacePackages($packages);
 
         foreach ($packages as $package) {
-            $this->replaceParentPackage($package, null);
+            $this->replacer->replaceParentPackage($package, null);
         }
     }
 
@@ -106,43 +106,6 @@ class Compose extends Command
         }
 
         $this->replacer->replacePackage($package);
-    }
-
-    protected function replaceParentPackage(Package $package, $parent)
-    {
-        if ($parent !== null) {
-            // Replace everything in parent, based on the dependencies
-            foreach ($parent->autoloaders as $parentAutoloader) {
-                foreach ($package->autoloaders as $autoloader) {
-                    if ($parentAutoloader instanceof NamespaceAutoloader) {
-                        $namespace = str_replace('\\', '/', $parentAutoloader->namespace);
-                        $directory = $this->workingDir . $this->config->dep_directory . $namespace . '/';
-
-                        if ($autoloader instanceof NamespaceAutoloader) {
-                            $this->replacer->replaceInDirectory($autoloader, $directory);
-                        } else {
-                            $directory = str_replace($this->workingDir, '', $directory);
-                            $this->replacer->replaceParentClassesInDirectory($directory);
-                        }
-                    } else {
-                        $directory = $this->workingDir . $this->config->classmap_directory . $parent->config->name;
-
-                        if ($autoloader instanceof NamespaceAutoloader) {
-                            $this->replacer->replaceInDirectory($autoloader, $directory);
-                        } else {
-                            $directory = str_replace($this->workingDir, '', $directory);
-                            $this->replacer->replaceParentClassesInDirectory($directory);
-                        }
-                    }
-                }
-            }
-        }
-
-        if (! empty($package->dependencies)) {
-            foreach ($package->dependencies as $dependency) {
-                $this->replaceParentPackage($dependency, $package);
-            }
-        }
     }
 
     /**

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -25,18 +25,37 @@ class Compose extends Command
         $config = json_decode(file_get_contents($workingDir . '/composer.json'));
         $config = $config->extra->mozart;
 
+        $packages = $this->findPackages($workingDir, $config->packages);
+
+        $this->movePackages($workingDir, $config, $packages);
+        $this->replacePackages($workingDir, $config, $packages);
+    }
+
+    /**
+     * @param $workingDir
+     * @param $config
+     * @param array $packages
+     */
+    protected function movePackages($workingDir, $config, $packages)
+    {
         $mover = new Mover($workingDir, $config);
         $mover->deleteTargetDirs();
 
-        $packages = $this->findPackages($workingDir, $config->packages);
-
-        foreach( $packages as $package ) {
+        foreach ($packages as $package) {
             $this->movePackage($package, $mover);
         }
+    }
 
+    /**
+     * @param $workingDir
+     * @param $config
+     * @param array $packages
+     */
+    protected function replacePackages($workingDir, $config, $packages)
+    {
         $replacer = new Replacer($workingDir, $config);
 
-        foreach( $packages as $package ) {
+        foreach ($packages as $package) {
             $this->replacePackage($package, $replacer);
         }
     }

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -49,7 +49,7 @@ class Compose extends Command
         $this->movePackages($packages);
         $this->replacePackages($packages);
 
-        foreach( $packages as $package ) {
+        foreach ($packages as $package) {
             $this->replaceParentPackage($package, null);
         }
     }
@@ -85,8 +85,8 @@ class Compose extends Command
      */
     public function movePackage($package)
     {
-        if ( ! empty( $package->dependencies ) ) {
-            foreach( $package->dependencies as $dependency ) {
+        if (! empty($package->dependencies)) {
+            foreach ($package->dependencies as $dependency) {
                 $this->movePackage($dependency);
             }
         }
@@ -99,8 +99,8 @@ class Compose extends Command
      */
     public function replacePackage($package)
     {
-        if ( ! empty( $package->dependencies ) ) {
-            foreach( $package->dependencies as $dependency ) {
+        if (! empty($package->dependencies)) {
+            foreach ($package->dependencies as $dependency) {
                 $this->replacePackage($dependency);
             }
         }
@@ -110,14 +110,15 @@ class Compose extends Command
 
     protected function replaceParentPackage(Package $package, $parent)
     {
-        if ( $parent !== null ) {
+        if ($parent !== null) {
             // Replace everything in parent, based on the dependencies
-            foreach( $parent->autoloaders as $parentAutoloader ) {
-                foreach( $package->autoloaders as $autoloader ) {
+            foreach ($parent->autoloaders as $parentAutoloader) {
+                foreach ($package->autoloaders as $autoloader) {
                     if ($parentAutoloader instanceof NamespaceAutoloader) {
-                        $directory = $this->workingDir . $this->config->dep_directory . str_replace('\\', '/', $parentAutoloader->namespace) . '/';
+                        $namespace = str_replace('\\', '/', $parentAutoloader->namespace);
+                        $directory = $this->workingDir . $this->config->dep_directory . $namespace . '/';
 
-                        if ( $autoloader instanceof NamespaceAutoloader ) {
+                        if ($autoloader instanceof NamespaceAutoloader) {
                             $this->replacer->replaceInDirectory($autoloader, $directory);
                         } else {
                             $directory = str_replace($this->workingDir, '', $directory);
@@ -126,7 +127,7 @@ class Compose extends Command
                     } else {
                         $directory = $this->workingDir . $this->config->classmap_directory . $parent->config->name;
 
-                        if ( $autoloader instanceof NamespaceAutoloader ) {
+                        if ($autoloader instanceof NamespaceAutoloader) {
                             $this->replacer->replaceInDirectory($autoloader, $directory);
                         } else {
                             $directory = str_replace($this->workingDir, '', $directory);
@@ -137,7 +138,7 @@ class Compose extends Command
             }
         }
 
-        if ( ! empty($package->dependencies)) {
+        if (! empty($package->dependencies)) {
             foreach ($package->dependencies as $dependency) {
                 $this->replaceParentPackage($dependency, $package);
             }
@@ -155,7 +156,7 @@ class Compose extends Command
         foreach ($slugs as $package_slug) {
             $packageDir = $this->workingDir . '/vendor/' . $package_slug .'/';
 
-            if (! is_dir($packageDir) ) {
+            if (! is_dir($packageDir)) {
                 continue;
             }
 
@@ -165,7 +166,7 @@ class Compose extends Command
             $config = json_decode(file_get_contents($packageDir . 'composer.json'));
 
             $dependencies = [];
-            if ( isset( $config->require) ) {
+            if (isset($config->require)) {
                 $dependencies = array_keys((array)$config->require);
             }
 

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -4,6 +4,7 @@ namespace CoenJacobs\Mozart\Console\Commands;
 
 use CoenJacobs\Mozart\Composer\Package;
 use CoenJacobs\Mozart\Mover;
+use CoenJacobs\Mozart\Replacer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,6 +33,12 @@ class Compose extends Command
         foreach( $packages as $package ) {
             $this->movePackage($package, $mover);
         }
+
+        $replacer = new Replacer($workingDir, $config);
+
+        foreach( $packages as $package ) {
+            $this->replacePackage($package, $replacer);
+        }
     }
 
     /**
@@ -46,6 +53,20 @@ class Compose extends Command
         }
 
         $mover->movePackage($package);
+    }
+
+    /**
+     * Replace contents of all the packages, one by one, starting on the deepest level of dependencies.
+     */
+    public function replacePackage($package, $replacer)
+    {
+        if ( ! empty( $package->dependencies ) ) {
+            foreach( $package->dependencies as $dependency ) {
+                $this->replacePackage($dependency, $replacer);
+            }
+        }
+
+        $replacer->replacePackage($package);
     }
 
     /**

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -2,6 +2,8 @@
 
 namespace CoenJacobs\Mozart\Console\Commands;
 
+use CoenJacobs\Mozart\Composer\Autoload\Classmap;
+use CoenJacobs\Mozart\Composer\Autoload\NamespaceAutoloader;
 use CoenJacobs\Mozart\Composer\Package;
 use CoenJacobs\Mozart\Mover;
 use CoenJacobs\Mozart\Replacer;
@@ -112,8 +114,25 @@ class Compose extends Command
             // Replace everything in parent, based on the dependencies
             foreach( $parent->autoloaders as $parentAutoloader ) {
                 foreach( $package->autoloaders as $autoloader ) {
-                    $directory = $this->workingDir . $this->config->dep_directory . str_replace('\\', '/', $parentAutoloader->namespace) . '/';
-                    $this->replacer->replaceInDirectory($autoloader, $directory);
+                    if ($parentAutoloader instanceof NamespaceAutoloader) {
+                        $directory = $this->workingDir . $this->config->dep_directory . str_replace('\\', '/', $parentAutoloader->namespace) . '/';
+
+                        if ( $autoloader instanceof NamespaceAutoloader ) {
+                            $this->replacer->replaceInDirectory($autoloader, $directory);
+                        } else {
+                            $directory = str_replace($this->workingDir, '', $directory);
+                            $this->replacer->replaceParentClassesInDirectory($directory);
+                        }
+                    } else {
+                        $directory = $this->workingDir . $this->config->classmap_directory . $parent->config->name;
+
+                        if ( $autoloader instanceof NamespaceAutoloader ) {
+                            $this->replacer->replaceInDirectory($autoloader, $directory);
+                        } else {
+                            $directory = str_replace($this->workingDir, '', $directory);
+                            $this->replacer->replaceParentClassesInDirectory($directory);
+                        }
+                    }
                 }
             }
         }

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -45,7 +45,7 @@ class Mover
         $finder = new Finder();
 
         foreach ($package->autoloaders as $autoloader) {
-            if ($autoloader instanceof NamespaceAutoloader ) {
+            if ($autoloader instanceof NamespaceAutoloader) {
                 foreach ($autoloader->paths as $path) {
                     $source_path = $this->workingDir . '/vendor/' . $package->config->name . '/' . $path;
 
@@ -86,7 +86,8 @@ class Mover
      * @param $path
      * @return mixed
      */
-    public function moveFile(Package $package, $autoloader, $file, $path = '')   {
+    public function moveFile(Package $package, $autoloader, $file, $path = '')
+    {
         if ($autoloader instanceof NamespaceAutoloader) {
             $namespacePath = $autoloader->getNamespacePath();
             $replaceWith = $this->config->dep_directory . $namespacePath;

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -45,17 +45,17 @@ class Mover
         $finder = new Finder();
 
         foreach ($package->autoloaders as $autoloader) {
-            foreach ($autoloader->paths as $path) {
-                $source_path = $this->workingDir . '/vendor/' . $package->config->name . '/' . $path;
+            if ($autoloader instanceof NamespaceAutoloader ) {
+                foreach ($autoloader->paths as $path) {
+                    $source_path = $this->workingDir . '/vendor/' . $package->config->name . '/' . $path;
 
-                $finder->files()->in($source_path);
+                    $finder->files()->in($source_path);
 
-                foreach ($finder as $file) {
-                    $this->moveFile($package, $autoloader, $file, $path);
+                    foreach ($finder as $file) {
+                        $this->moveFile($package, $autoloader, $file, $path);
+                    }
                 }
-            }
-
-            if ($autoloader instanceof Classmap && ! empty($autoloader->files)) {
+            } elseif ($autoloader instanceof Classmap) {
                 foreach ($autoloader->files as $file) {
                     $finder = new Finder();
                     $source_path = $this->workingDir . '/vendor/' . $package->config->name;
@@ -63,6 +63,16 @@ class Mover
 
                     foreach ($finder as $foundFile) {
                         $this->moveFile($package, $autoloader, $foundFile);
+                    }
+                }
+
+                foreach ($autoloader->paths as $path) {
+                    $source_path = $this->workingDir . '/vendor/' . $package->config->name;
+
+                    $finder->files()->in($source_path);
+
+                    foreach ($finder as $file) {
+                        $this->moveFile($package, $autoloader, $file);
                     }
                 }
             }

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -42,10 +42,10 @@ class Mover
 
     public function movePackage(Package $package)
     {
-        $finder = new Finder();
-
         foreach ($package->autoloaders as $autoloader) {
             if ($autoloader instanceof NamespaceAutoloader) {
+                $finder = new Finder();
+
                 foreach ($autoloader->paths as $path) {
                     $source_path = $this->workingDir . '/vendor/' . $package->config->name . '/' . $path;
 
@@ -56,8 +56,9 @@ class Mover
                     }
                 }
             } elseif ($autoloader instanceof Classmap) {
+                $finder = new Finder();
+
                 foreach ($autoloader->files as $file) {
-                    $finder = new Finder();
                     $source_path = $this->workingDir . '/vendor/' . $package->config->name;
                     $finder->files()->name($file)->in($source_path);
 
@@ -65,6 +66,8 @@ class Mover
                         $this->moveFile($package, $autoloader, $foundFile);
                     }
                 }
+
+                $finder = new Finder();
 
                 foreach ($autoloader->paths as $path) {
                     $source_path = $this->workingDir . '/vendor/' . $package->config->name . '/' . $path;

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -22,9 +22,6 @@ class Mover
     /** @var \stdClass */
     protected $config;
 
-    /** @var array */
-    protected $replacedClasses = [];
-
     /** @var Filesystem */
     protected $filesystem;
 
@@ -56,11 +53,7 @@ class Mover
                 $finder->files()->in($source_path);
 
                 foreach ($finder as $file) {
-                    $targetFile = $this->moveFile($package, $autoloader, $file, $path);
-
-                    if ('.php' == substr($targetFile, '-4', 4)) {
-                        $this->replaceInFile($targetFile, $autoloader);
-                    }
+                    $this->moveFile($package, $autoloader, $file, $path);
                 }
             }
 
@@ -71,11 +64,7 @@ class Mover
                     $finder->files()->name($file)->in($source_path);
 
                     foreach ($finder as $foundFile) {
-                        $targetFile = $this->moveFile($package, $autoloader, $foundFile);
-
-                        if ('.php' == substr($targetFile, '-4', 4)) {
-                            $this->replaceInFile($targetFile, $autoloader);
-                        }
+                        $this->moveFile($package, $autoloader, $foundFile);
                     }
                 }
             }
@@ -108,57 +97,5 @@ class Mover
         );
 
         return $targetFile;
-    }
-
-    public function replaceClassmapNames()
-    {
-        $classmap_path = $this->workingDir . $this->config->classmap_directory;
-        $finder = new Finder();
-        $finder->files()->in($classmap_path);
-
-        $filesystem = new Filesystem(new Local($this->workingDir));
-
-        foreach ($finder as $file) {
-            $file_path = str_replace($this->workingDir, '', $file->getRealPath());
-            $contents = $filesystem->read($file_path);
-
-            foreach ($this->replacedClasses as $original => $replacement) {
-                $contents = preg_replace_callback(
-                    '/\W(?<!(trait)\ )(?<!(interface)\ )(?<!(class)\ )('.$original.')\W/U',
-                    function ($matches) use ($replacement) {
-                        return str_replace($matches[4], $replacement, $matches[0]);
-                    },
-                    $contents
-                );
-            }
-
-            $filesystem->put($file_path, $contents);
-        }
-    }
-
-    /**
-     * @param $targetFile
-     * @param $autoloader
-     */
-    public function replaceInFile($targetFile, $autoloader)
-    {
-        $contents = $this->filesystem->read($targetFile);
-
-        if ($autoloader instanceof NamespaceAutoloader) {
-            $replacer = new NamespaceReplacer();
-            $replacer->dep_namespace = $this->config->dep_namespace;
-        } else {
-            $replacer = new ClassmapReplacer();
-            $replacer->classmap_prefix = $this->config->classmap_prefix;
-        }
-
-        $replacer->setAutoloader($autoloader);
-        $contents = $replacer->replace($contents);
-
-        if ($replacer instanceof ClassmapReplacer) {
-            $this->replacedClasses = array_merge($this->replacedClasses, $replacer->replacedClasses);
-        }
-
-        $this->filesystem->put($targetFile, $contents);
     }
 }

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -67,7 +67,7 @@ class Mover
                 }
 
                 foreach ($autoloader->paths as $path) {
-                    $source_path = $this->workingDir . '/vendor/' . $package->config->name;
+                    $source_path = $this->workingDir . '/vendor/' . $package->config->name . '/' . $path;
 
                     $finder->files()->in($source_path);
 

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -5,8 +5,6 @@ namespace CoenJacobs\Mozart;
 use CoenJacobs\Mozart\Composer\Autoload\Classmap;
 use CoenJacobs\Mozart\Composer\Autoload\NamespaceAutoloader;
 use CoenJacobs\Mozart\Composer\Package;
-use CoenJacobs\Mozart\Replace\ClassmapReplacer;
-use CoenJacobs\Mozart\Replace\NamespaceReplacer;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -86,7 +84,7 @@ class Mover
             $targetFile = str_replace('/vendor/' . $package->config->name . '/' . $path, '', $targetFile);
         } else {
             $namespacePath = $package->config->name;
-            $replaceWith = $this->config->classmap_directory . $namespacePath;
+            $replaceWith = $this->config->classmap_directory . '/' . $namespacePath;
             $targetFile = str_replace($this->workingDir, $replaceWith, $file->getRealPath());
             $targetFile = str_replace('/vendor/' . $package->config->name . '/', '/', $targetFile);
         }

--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -113,7 +113,7 @@ class Replacer
             if ('.php' == substr($targetFile, '-4', 4)) {
                 $contents = $this->filesystem->read($targetFile);
 
-                foreach( $replacedClasses as $key => $value ) {
+                foreach ($replacedClasses as $key => $value) {
                     $contents = str_replace($key, $value, $contents);
                 }
 

--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace CoenJacobs\Mozart;
+
+use CoenJacobs\Mozart\Composer\Autoload\Classmap;
+use CoenJacobs\Mozart\Composer\Autoload\NamespaceAutoloader;
+use CoenJacobs\Mozart\Composer\Package;
+use CoenJacobs\Mozart\Replace\ClassmapReplacer;
+use CoenJacobs\Mozart\Replace\NamespaceReplacer;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class Replacer
+{
+    /** @var string */
+    protected $workingDir;
+
+    /** @var string */
+    protected $targetDir;
+
+    /** @var \stdClass */
+    protected $config;
+
+    /** @var array */
+    protected $replacedClasses = [];
+
+    /** @var Filesystem */
+    protected $filesystem;
+
+    public function __construct($workingDir, $config)
+    {
+        $this->workingDir = $workingDir;
+        $this->targetDir = $config->dep_directory;
+        $this->config = $config;
+
+        $this->filesystem = new Filesystem(new Local($this->workingDir));
+    }
+
+    public function replacePackage(Package $package)
+    {
+        $finder = new Finder();
+
+        foreach ($package->autoloaders as $autoloader) {
+            $source_path = $this->workingDir . $this->targetDir . str_replace('\\', '/', $autoloader->namespace) .'/';
+            $finder->files()->in($source_path);
+
+            foreach ($finder as $file) {
+                $targetFile = $file->getPathName();
+
+                if ('.php' == substr($targetFile, '-4', 4)) {
+                    $this->replaceInFile($targetFile, $autoloader);
+                }
+            }
+
+            if ($autoloader instanceof Classmap && ! empty($autoloader->files)) {
+                foreach ($autoloader->files as $file) {
+                    $finder = new Finder();
+                    $source_path = $this->workingDir . $this->targetDir . $package->config->name;
+                    $finder->files()->name($file)->in($source_path);
+
+                    foreach ($finder as $foundFile) {
+                        $targetFile = $foundFile->getRealPath();
+
+                        if ('.php' == substr($targetFile, '-4', 4)) {
+                            $this->replaceInFile($targetFile, $autoloader);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public function replaceClassmapNames()
+    {
+        $classmap_path = $this->workingDir . $this->config->classmap_directory;
+        $finder = new Finder();
+        $finder->files()->in($classmap_path);
+
+        $filesystem = new Filesystem(new Local($this->workingDir));
+
+        foreach ($finder as $file) {
+            $file_path = str_replace($this->workingDir, '', $file->getPath());
+            $contents = $filesystem->read($file_path);
+
+            foreach ($this->replacedClasses as $original => $replacement) {
+                $contents = preg_replace_callback(
+                    '/\W(?<!(trait)\ )(?<!(interface)\ )(?<!(class)\ )('.$original.')\W/U',
+                    function ($matches) use ($replacement) {
+                        return str_replace($matches[4], $replacement, $matches[0]);
+                    },
+                    $contents
+                );
+            }
+
+            $filesystem->put($file_path, $contents);
+        }
+    }
+
+    /**
+     * @param $targetFile
+     * @param $autoloader
+     */
+    public function replaceInFile($targetFile, $autoloader)
+    {
+        $targetFile = str_replace($this->workingDir, '', $targetFile);
+        $contents = $this->filesystem->read($targetFile);
+
+        if ($autoloader instanceof NamespaceAutoloader) {
+            $replacer = new NamespaceReplacer();
+            $replacer->dep_namespace = $this->config->dep_namespace;
+        } else {
+            $replacer = new ClassmapReplacer();
+            $replacer->classmap_prefix = $this->config->classmap_prefix;
+        }
+
+        $replacer->setAutoloader($autoloader);
+        $contents = $replacer->replace($contents);
+
+        if ($replacer instanceof ClassmapReplacer) {
+            $this->replacedClasses = array_merge($this->replacedClasses, $replacer->replacedClasses);
+        }
+
+        $this->filesystem->put($targetFile, $contents);
+    }
+}

--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -99,6 +99,33 @@ class Replacer
      * @param $autoloader
      * @param $directory
      */
+    public function replaceParentClassesInDirectory($directory)
+    {
+        $directory = trim($directory, '//');
+        $finder = new Finder();
+        $finder->files()->in($directory);
+
+        $replacedClasses = $this->replacedClasses;
+
+        foreach ($finder as $file) {
+            $targetFile = $file->getPathName();
+
+            if ('.php' == substr($targetFile, '-4', 4)) {
+                $contents = $this->filesystem->read($targetFile);
+
+                foreach( $replacedClasses as $key => $value ) {
+                    $contents = str_replace($key, $value, $contents);
+                }
+
+                $this->filesystem->put($targetFile, $contents);
+            }
+        }
+    }
+
+    /**
+     * @param $autoloader
+     * @param $directory
+     */
     public function replaceInDirectory($autoloader, $directory)
     {
         $finder = new Finder();

--- a/tests/replacers/ClassMapReplacerTest.php
+++ b/tests/replacers/ClassMapReplacerTest.php
@@ -66,7 +66,8 @@ class ClassMapReplacerTest extends TestCase
     }
 
     /** @test */
-    public function it_replaces_class_declarations_psr2() {
+    public function it_replaces_class_declarations_psr2()
+    {
         $contents = "class Hello_World\n{";
         $replacer = new ClassmapReplacer();
         $replacer->classmap_prefix = 'Mozart_';

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -30,7 +30,8 @@ class NamespaceReplacerTest extends TestCase
 
 
     /** @test */
-    public function it_doesnt_replaces_namespace_inside_namespace() {
+    public function it_doesnt_replaces_namespace_inside_namespace()
+    {
 
         $autoloader = new Psr0();
         $autoloader->namespace = 'Test';


### PR DESCRIPTION
This pull request is very much inspired by #10 by @costasovo, but I eventually landed on a different approach, using recursion. This allows for virtually no limits in the depth of the dependency tree.

I've also settled on removing the ability to disable processing dependencies, as that is beyond the scope of this project. If a package has a dependency, it needs to be processed as well, in order to maintain the bundled, prefixed dependencies in WordPress plugins.

I'd like some testing on this pull request before I release it - any feedback is greatly appreciated! 😄 

This pull request eventually closes #1.