### PR TITLE
Skip already moved packages

### DIFF
--- a/src/Mover.php
+++ b/src/Mover.php
@@ -23,6 +23,9 @@ class Mover
     /** @var Filesystem */
     protected $filesystem;
 
+    /** @var array */
+    protected $movedPackages = [];
+
     public function __construct($workingDir, $config)
     {
         $this->workingDir = $workingDir;
@@ -42,6 +45,10 @@ class Mover
 
     public function movePackage(Package $package)
     {
+        if ( in_array( $package->config->name, $this->movedPackages ) ) {
+            return;
+        }
+
         foreach ($package->autoloaders as $autoloader) {
             if ($autoloader instanceof NamespaceAutoloader) {
                 $finder = new Finder();
@@ -79,6 +86,8 @@ class Mover
                     }
                 }
             }
+
+            $this->movedPackages[] = $package->config->name;
         }
     }
 

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -9,7 +9,7 @@ class NamespaceReplacerTest extends TestCase
     /** @var NamespaceReplacer */
     public $replacer;
 
-    public function setUp()
+    protected function setUp()
     {
         $autoloader = new Psr0();
         $autoloader->namespace = 'Test\\Test';


### PR DESCRIPTION
This can go in the next fix release. Each package should only be moved/replaced once, even if the full dependency tree has the same package multiple times. Fixes #17.