### PR TITLE
Support Symfony v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5.0",
-        "symfony/console": "^3.2",
-        "symfony/finder": "^3.2",
+        "symfony/console": "^3.2 || ^4",
+        "symfony/finder": "^3.2 || ^4",
         "league/flysystem": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
Symfony v4 should by now be the go-to version, and Mozart should properly support it.

Fixes #24 