### PR TITLE
Delete original package directory

### DIFF
--- a/src/Mover.php
+++ b/src/Mover.php
@@ -90,10 +90,7 @@ class Mover
             $this->movedPackages[] = $package->config->name;
         }
 
-        foreach( $this->movedPackages as $movedPackage ) {
-            $packageDir = '/vendor/' . $movedPackage;
-            $this->filesystem->deleteDir($packageDir);
-        }
+        $this->deletePackageVendorDirectories();
     }
 
     /**
@@ -129,5 +126,18 @@ class Mover
         );
 
         return $targetFile;
+    }
+
+    /**
+     * Deletes all the packages that are moved from the /vendor/ directory to
+     * prevent packages that are prefixed/namespaced from being used or
+     * influencing the output of the code. They just need to be gone.
+     */
+    protected function deletePackageVendorDirectories()
+    {
+        foreach ($this->movedPackages as $movedPackage) {
+            $packageDir = '/vendor/' . $movedPackage;
+            $this->filesystem->deleteDir($packageDir);
+        }
     }
 }

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -91,7 +91,7 @@ class Mover
         }
 
         foreach( $this->movedPackages as $movedPackage ) {
-            $packageDir = $this->workingDir . '/vendor/' . $movedPackage;
+            $packageDir = '/vendor/' . $movedPackage;
             $this->filesystem->deleteDir($packageDir);
         }
     }

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -89,6 +89,11 @@ class Mover
 
             $this->movedPackages[] = $package->config->name;
         }
+
+        foreach( $this->movedPackages as $movedPackage ) {
+            $packageDir = $this->workingDir . '/vendor/' . $movedPackage;
+            $this->filesystem->deleteDir($packageDir);
+        }
     }
 
     /**


### PR DESCRIPTION
Some packages, including [`twig/twig`](https://packagist.org/packages/twig/twig), have some safeguard mechanisms in place that prevent an older version (1.x) and a newer version (3.x) of the same package to be active. This is done by checking if the _new_ version of the class is available, before loading the _old_ version of the class.

Use case where this was found: A plugin using Mozart to bundle Twig (on 3.x, preferably), while the theme used Twig 1.x without Mozart. Even though the replace went fine and the prefixed/namespaced classes of Twig are being used in the plugin, the version of Twig being loaded by the theme then still detected the _new_ Twig version inside the `/vendor` directory which is being autoloaded. So, this pull request deletes the packages from the `/vendor` directory after they have been moved to the new directory.

This has been brought to my attention by @Willemijnr, who has been using my package in one of our Level Level projects - so props to her! 🎉 