### PR TITLE
0.5 release, version bumps and hello future!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 
 .DS_Store
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 install:
   - composer selfupdate --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "prefer-stable": true,
     "license": "MIT",
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "symfony/console": "^4",
         "symfony/finder": "^4",
         "league/flysystem": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^8.5",
         "coenjacobs/php-composter-phpcs": "^0.1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "symfony/console": "^4",
-        "symfony/finder": "^4",
+        "symfony/console": "^4|^5",
+        "symfony/finder": "^4|^5",
         "league/flysystem": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
-        "coenjacobs/php-composter-phpcs": "^0.1.0"
+        "phpunit/phpunit": "^8.5"
     }
 }


### PR DESCRIPTION
PHP 7.2 is now required. All used packages can be bumped. On to a more modern PHP world!