### PR TITLE
Use getPathname() for symlinked packages

### DIFF
--- a/src/Mover.php
+++ b/src/Mover.php
@@ -105,7 +105,7 @@ class Mover
         if ($autoloader instanceof NamespaceAutoloader) {
             $namespacePath = $autoloader->getNamespacePath();
             $replaceWith = $this->config->dep_directory . $namespacePath;
-            $targetFile = str_replace($this->workingDir, $replaceWith, $file->getRealPath());
+            $targetFile = str_replace($this->workingDir, $replaceWith, $file->getPathname());
 
             $packageVendorPath = '/vendor/' . $package->config->name . '/' . $path;
             $packageVendorPath = str_replace('/', DIRECTORY_SEPARATOR, $packageVendorPath);
@@ -113,7 +113,7 @@ class Mover
         } else {
             $namespacePath = $package->config->name;
             $replaceWith = $this->config->classmap_directory . '/' . $namespacePath;
-            $targetFile = str_replace($this->workingDir, $replaceWith, $file->getRealPath());
+            $targetFile = str_replace($this->workingDir, $replaceWith, $file->getPathname());
 
             $packageVendorPath = '/vendor/' . $package->config->name . '/';
             $packageVendorPath = str_replace('/', DIRECTORY_SEPARATOR, $packageVendorPath);
@@ -121,7 +121,7 @@ class Mover
         }
 
         $this->filesystem->copy(
-            str_replace($this->workingDir, '', $file->getRealPath()),
+            str_replace($this->workingDir, '', $file->getPathname()),
             $targetFile
         );
 

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -2,12 +2,14 @@
 
 namespace CoenJacobs\Mozart;
 
+use CoenJacobs\Mozart\Composer\Autoload\Autoloader;
 use CoenJacobs\Mozart\Composer\Autoload\Classmap;
 use CoenJacobs\Mozart\Composer\Autoload\NamespaceAutoloader;
 use CoenJacobs\Mozart\Composer\Package;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class Mover
 {
@@ -95,10 +97,10 @@ class Mover
 
     /**
      * @param Package $package
-     * @param $autoloader
-     * @param $file
-     * @param $path
-     * @return mixed
+     * @param Autoloader $autoloader
+     * @param SplFileInfo $file
+     * @param string $path
+     * @return string
      */
     public function moveFile(Package $package, $autoloader, $file, $path = '')
     {


### PR DESCRIPTION
`League\Flysystem\Filesystem->copy()` was giving a `FileNotFoundException` when moving files from a package that was added as symlink using:

```
"repositories": {
  "type": "path"
  "url": "path/outside/project/workingdir"
}
```

It seems it can only copy from inside the working directory.

This was fixed by replacing `getRealPath()` with `getPathname()`.

Unfortunately this might not be the best solution, from [flysystem/CHANGELOG.md](https://github.com/thephpleague/flysystem/blob/021569195e15f8209b1c4bebb78bd66aa4f08c21/CHANGELOG.md#L369) :
```
- [Adapter\Local] Symlinks are now explicitly not supported, this was previously broken.
```
