### PR TITLE
Classmap replacing change str_replace to regex

### DIFF
--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -71,6 +71,28 @@ class Replacer
         $this->filesystem->put($targetFile, $contents);
     }
 
+	/**
+	 * @param $targetFile
+	 * @param array $replacedClasses
+	 */
+	public function replaceClassesInFile($targetFile, $replacedClasses)
+	{
+		$targetFile = str_replace($this->workingDir, '', $targetFile);
+		$contents = $this->filesystem->read($targetFile);
+
+		foreach($replacedClasses as $original => $replacement) {
+			$contents = preg_replace_callback(
+				'/([^a-zA-Z0-9_\x7f-\xff])'. $original . '([^a-zA-Z0-9_\x7f-\xff])/U',
+				function ($matches) use ($replacement) {
+					return $matches[1] . $replacement . $matches[2];
+				},
+				$contents
+			);
+		}
+
+		$this->filesystem->put($targetFile, $contents);
+	}
+
     /**
      * @param Package $package
      * @param $autoloader
@@ -92,6 +114,14 @@ class Replacer
                     $this->replaceInFile($targetFile, $autoloader);
                 }
             }
+
+	        foreach ($finder as $foundFile) {
+		        $targetFile = $foundFile->getRealPath();
+
+		        if ('.php' == substr($targetFile, '-4', 4)) {
+			        $this->replaceClassesInFile($targetFile, $this->replacedClasses);
+		        }
+	        }
         }
     }
 

--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -116,9 +116,12 @@ class Replacer
 
 	            foreach ($replacedClasses as $original => $replacement) {
 		            $contents = preg_replace_callback(
-			            '/([^a-zA-Z0-9_\x7f-\xff])'. $original . '([^a-zA-Z0-9_\x7f-\xff])/U',
+			            '/(.*)([^a-zA-Z0-9_\x7f-\xff])'. $original . '([^a-zA-Z0-9_\x7f-\xff])/U',
 			            function ($matches) use ($replacement) {
-				            return $matches[1] . $replacement . $matches[2];
+				            if(preg_match('/(include|require)/', $matches[0], $output_array)) {
+					            return $matches[0];
+				            }
+				            return $matches[2] . $replacement . $matches[3];
 			            },
 			            $contents
 		            );

--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -121,7 +121,7 @@ class Replacer
 				            if(preg_match('/(include|require)/', $matches[0], $output_array)) {
 					            return $matches[0];
 				            }
-				            return $matches[2] . $replacement . $matches[3];
+				            return $matches[1] . $matches[2] . $replacement . $matches[3];
 			            },
 			            $contents
 		            );

--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -71,28 +71,6 @@ class Replacer
         $this->filesystem->put($targetFile, $contents);
     }
 
-	/**
-	 * @param $targetFile
-	 * @param array $replacedClasses
-	 */
-	public function replaceClassesInFile($targetFile, $replacedClasses)
-	{
-		$targetFile = str_replace($this->workingDir, '', $targetFile);
-		$contents = $this->filesystem->read($targetFile);
-
-		foreach($replacedClasses as $original => $replacement) {
-			$contents = preg_replace_callback(
-				'/([^a-zA-Z0-9_\x7f-\xff])'. $original . '([^a-zA-Z0-9_\x7f-\xff])/U',
-				function ($matches) use ($replacement) {
-					return $matches[1] . $replacement . $matches[2];
-				},
-				$contents
-			);
-		}
-
-		$this->filesystem->put($targetFile, $contents);
-	}
-
     /**
      * @param Package $package
      * @param $autoloader
@@ -114,14 +92,7 @@ class Replacer
                     $this->replaceInFile($targetFile, $autoloader);
                 }
             }
-
-	        foreach ($finder as $foundFile) {
-		        $targetFile = $foundFile->getRealPath();
-
-		        if ('.php' == substr($targetFile, '-4', 4)) {
-			        $this->replaceClassesInFile($targetFile, $this->replacedClasses);
-		        }
-	        }
+            
         }
     }
 
@@ -143,9 +114,15 @@ class Replacer
             if ('.php' == substr($targetFile, '-4', 4)) {
                 $contents = $this->filesystem->read($targetFile);
 
-                foreach ($replacedClasses as $key => $value) {
-                    $contents = str_replace($key, $value, $contents);
-                }
+	            foreach ($replacedClasses as $original => $replacement) {
+		            $contents = preg_replace_callback(
+			            '/([^a-zA-Z0-9_\x7f-\xff])'. $original . '([^a-zA-Z0-9_\x7f-\xff])/U',
+			            function ($matches) use ($replacement) {
+				            return $matches[1] . $replacement . $matches[2];
+			            },
+			            $contents
+		            );
+	            }
 
                 $this->filesystem->put($targetFile, $contents);
             }


### PR DESCRIPTION
For some reason, your code wasn't replacing references to the updated class names so I wrote the code myself before yours started working again. Odd.

Anyway, there was still an issue with doubled-up names, so I replaced the str_replace with a regex for more precise replacing.

~~After the classmap replacer processes each file and the `Replacer->replacedClasses` property is populated, the files are revisited and the changes implemented throughout.~~

e.g.
```
class BH_Google_Collection extends Google_Model implements Iterator, Countable
```
is now
```
class BH_Google_Collection extends BH_Google_Model implements Iterator, Countable
```
and
```
if (!class_exists('Google_Client')) {
```
is now
```
if (!class_exists('BH_Google_Client')) {
```
