### PR TITLE
Fixed escaping of backslash

### DIFF
--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -11,7 +11,7 @@ class NamespaceReplacer extends BaseReplacer
     {
         $searchNamespace = $this->autoloader->getSearchNamespace();
         return preg_replace_callback(
-            '/([^\\\?])(' . addslashes($searchNamespace) . '[\\\|;])/U',
+            '/([^a-zA-Z0-9_\x7f-\xff])(' . addslashes($searchNamespace) . '[\\\|;])/U',
             function ($matches) {
                 return $matches[1] . $this->dep_namespace . $matches[2];
             },

--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -11,7 +11,7 @@ class NamespaceReplacer extends BaseReplacer
     {
         $searchNamespace = $this->autoloader->getSearchNamespace();
         return preg_replace_callback(
-            '/([^a-zA-Z0-9_\x7f-\xff])(' . addslashes($searchNamespace) . '[\\\|;])/U',
+	        '/([^a-zA-Z0-9_\x7f-\xff\\\\])(' . addslashes($searchNamespace) . '[\\\\|;])/U',
             function ($matches) {
                 return $matches[1] . $this->dep_namespace . $matches[2];
             },

--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -11,7 +11,7 @@ class NamespaceReplacer extends BaseReplacer
     {
         $searchNamespace = $this->autoloader->getSearchNamespace();
         return preg_replace_callback(
-	        '/([^a-zA-Z0-9_\x7f-\xff])((?<!' . addslashes( $this->dep_namespace ) . ' )' . addslashes($searchNamespace) . '[\\\|;])/U',
+	        '/([^a-zA-Z0-9_\x7f-\xff])((?<!' . addslashes( $this->dep_namespace ) . ')' . addslashes($searchNamespace) . '[\\\|;])/U',
             function ($matches) {
                 return $matches[1] . $this->dep_namespace . $matches[2];
             },

--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -11,7 +11,7 @@ class NamespaceReplacer extends BaseReplacer
     {
         $searchNamespace = $this->autoloader->getSearchNamespace();
         return preg_replace_callback(
-	        '/([^a-zA-Z0-9_\x7f-\xff\\\\])(' . addslashes($searchNamespace) . '[\\\\|;])/U',
+	        '/([^a-zA-Z0-9_\x7f-\xff]\\\\?)(' . addslashes($searchNamespace) . '[\\\\|;])/U',
             function ($matches) {
                 return $matches[1] . $this->dep_namespace . $matches[2];
             },

--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -11,7 +11,7 @@ class NamespaceReplacer extends BaseReplacer
     {
         $searchNamespace = $this->autoloader->getSearchNamespace();
         return preg_replace_callback(
-	        '/([^a-zA-Z0-9_\x7f-\xff]\\\\?)(' . addslashes($searchNamespace) . '[\\\\|;])/U',
+	        '/([^a-zA-Z0-9_\x7f-\xff])((?<!' . addslashes( $this->dep_namespace ) . ' )' . addslashes($searchNamespace) . '[\\\|;])/U',
             function ($matches) {
                 return $matches[1] . $this->dep_namespace . $matches[2];
             },

--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -11,7 +11,7 @@ class NamespaceReplacer extends BaseReplacer
     {
         $searchNamespace = $this->autoloader->getSearchNamespace();
         return preg_replace_callback(
-            '/([^\\?])(' . addslashes($searchNamespace) . '[\\\|;])/U',
+            '/([^\\\?])(' . addslashes($searchNamespace) . '[\\\|;])/U',
             function ($matches) {
                 return $matches[1] . $this->dep_namespace . $matches[2];
             },

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -54,4 +54,18 @@ class NamespaceReplacerTest extends TestCase
         $contents = $this->replacer->replace($contents);
         $this->assertEquals('namespace Prefix\\Test\\Test\\Another;', $contents);
     }
+
+	/** @test */
+    public function it_doesnt_prefix_already_prefixed_namespace(): void {
+	    $autoloader = new Psr0();
+	    $autoloader->namespace = 'Test\\Another';
+
+	    $replacer = new NamespaceReplacer();
+	    $replacer->setAutoloader($autoloader);
+
+	    $contents = 'namespace Prefix\\Test\\Another;';
+	    $contents = $this->replacer->replace($contents);
+	    $this->assertEquals('namespace Prefix\\Test\\Another;', $contents);
+    }
+
 }


### PR DESCRIPTION
I was getting doubly prefixed classes in one case, I believe because the library (GuzzleHttp) was a dependency of two of my requirements.

The regex for excluding backslash, i.e. to only match from the beginning of classes, was incorrect. I have added a single `\` to properly escape the intended `\`.

![PhpStorm](https://imgur.com/0UfZjUw.png "Redundant character escape")