### PR TITLE
Allow overriding packages' autoload key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ Mozart requires little configuration. All you need to do is tell it where the bu
         "classmap_prefix": "CJTP_",
         "packages": [
             "pimple/pimple"
-        ]
+        ],
+        "override_autoload": {
+            "google/apiclient": {
+                "classmap": [
+                    "src/"
+                ]
+            }
+        }
     }
 },
 ```
@@ -41,6 +48,10 @@ The following configuration values are required:
 
 **Important:** Since Mozart automatically processes the full dependency tree of the packages you specify, you **need to specify all these configuration options**, because you can't reliably determine what kind of autoloaders are being used in the full dependency tree. A package way down the tree might suddenly use a classmap autoloader for example. Make sure you also include the namespace directory and classmap directory in your own autoloader, so they are always loaded.
 
+  The following configuration is optional:
+  
+- `override_autoload` a dictionary, keyed with the package names, of autoload settings to replace those in the original packages' `composer.json` `autoload` property.
+                
 After Composer has loaded the packages as defined in your `composer.json` file, you can now run `mozart compose` and Mozart will bundle your packages according to the above configuration. It is recommended to dump the autoloader after Mozart has finished running, in case there are new classes or namespaces generated that aren't included in the autoloader yet. 
 
 ## Scripts

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -18,10 +18,14 @@ class Package
     /** @var array */
     public $dependencies = [];
 
-    public function __construct($path)
-    {
-        $this->path   = $path;
-        $this->config = json_decode(file_get_contents($this->path . '/composer.json'));
+	public function __construct($path, $overrideAutoload = null)
+	{
+		$this->path   = $path;
+		$this->config = json_decode(file_get_contents($this->path . '/composer.json'));
+
+		if (isset($overrideAutoload)) {
+			$this->config->autoload = $overrideAutoload;
+		}
     }
 
     public function findAutoloaders()

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -125,7 +125,12 @@ class Compose extends Command
                 continue;
             }
 
-            $package = new Package($packageDir);
+	        $autoloaders = null;
+	        if (isset($this->config->override_autoload) && isset($this->config->override_autoload->$package_slug) ){
+		        $autoloaders = $this->config->override_autoload->$package_slug;
+	        }
+
+	        $package = new Package($packageDir, $autoloaders);
             $package->findAutoloaders();
 
             $config = json_decode(file_get_contents($packageDir . 'composer.json'));


### PR DESCRIPTION
Adds a configuration option to specify the autoload key in packages.

Needed for [google/apiclient](https://github.com/googleapis/google-api-php-client) but looks like it should help in issue #30 


