### PR TITLE
Do a classmap replace across the entire classmap_directory folder

### DIFF
--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -53,6 +53,8 @@ class Compose extends Command
             $this->replacer->replaceParentPackage($package, null);
         }
 
+	    $this->replacer->replaceParentClassesInDirectory( $this->config->classmap_directory );
+        
         return 0;
     }
 


### PR DESCRIPTION
This is a fix for the [Google PHP API](https://github.com/googleapis/google-api-php-client) having child package classes which extend classes in the parent package.

Mozart assumes only parent packages extend child package classes.

This does not feel like a robust change, but it does address the problem correctly.