### PR TITLE
Default packages – 6-beta-2 bugfix

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,8 +9,8 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="replacers">
-            <directory>./tests/replacers/</directory>
+        <testsuite name="all">
+            <directory>./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -65,7 +65,12 @@ class Compose extends Command
         $this->mover = new Mover($workingDir, $config);
         $this->replacer = new Replacer($workingDir, $config);
 
-        $require = empty($config->packages) ? array_keys(get_object_vars($this->config->require)) : $config->packages;
+        $require = array();
+        if (isset($config->packages) && is_array($config->packages)) {
+            $require = $config->packages;
+        } elseif (isset($composer->require) && is_array($composer->require)) {
+            $require = $composer->require;
+        }
 
         $packages = $this->findPackages($require);
 

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -69,7 +69,7 @@ class Compose extends Command
         if (isset($config->packages) && is_array($config->packages)) {
             $require = $config->packages;
         } elseif (isset($composer->require) && is_object($composer->require)) {
-	        $require = array_keys(get_object_vars($composer->require));
+            $require = array_keys(get_object_vars($composer->require));
         }
 
         $packages = $this->findPackages($require);

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -68,8 +68,8 @@ class Compose extends Command
         $require = array();
         if (isset($config->packages) && is_array($config->packages)) {
             $require = $config->packages;
-        } elseif (isset($composer->require) && is_array($composer->require)) {
-            $require = $composer->require;
+        } elseif (isset($composer->require) && is_object($composer->require)) {
+	        $require = array_keys(get_object_vars($composer->require));
         }
 
         $packages = $this->findPackages($require);

--- a/tests/Console/Commands/ComposeTest.php
+++ b/tests/Console/Commands/ComposeTest.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+
+use CoenJacobs\Mozart\Console\Commands\Compose;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ComposeTest extends TestCase
+{
+    static $cwd;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$cwd = getcwd();
+    }
+
+    /**
+     * Before each test ensure the current working directory is this one.
+     *
+     * Record the previous PHPUnit cwd to restore after.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        chdir(dirname(__FILE__));
+    }
+
+    /**
+     * When composer.json is absent, instead of failing with:
+     * "failed to open stream: No such file or directory"
+     * a better message should be written to the OutputInterface.
+     *
+     * @test
+     */
+    public function it_fails_gracefully_when_composer_json_absent(): void
+    {
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $outputInterfaceMock->expects($this->exactly(1))
+             ->method('write');
+
+        $compose = new class( $inputInterfaceMock, $outputInterfaceMock ) extends Compose {
+            public function __construct($inputInterfaceMock, $outputInterfaceMock)
+            {
+                parent::__construct();
+
+                $this->execute($inputInterfaceMock, $outputInterfaceMock);
+            }
+        };
+    }
+
+    /**
+     * When json_decode fails, instead of
+     * "Trying to get property 'extra' of non-object"
+     * a better message should be written to the OutputInterface.
+     *
+     * @test
+     */
+    public function it_handles_malformed_json_with_grace(): void
+    {
+
+        $badComposerJson = '{ "name": "coenjacobs/mozart", }';
+
+        file_put_contents(__DIR__ . '/composer.json', $badComposerJson);
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $outputInterfaceMock->expects($this->exactly(1))
+                            ->method('write');
+
+        $compose = new class( $inputInterfaceMock, $outputInterfaceMock ) extends Compose {
+            public function __construct($inputInterfaceMock, $outputInterfaceMock)
+            {
+                parent::__construct();
+
+                $this->execute($inputInterfaceMock, $outputInterfaceMock);
+            }
+        };
+    }
+
+    /**
+     * When composer.json->extra is absent, instead of
+     * "Undefined property: stdClass::$extra"
+     * a better message should be written to the OutputInterface.
+     *
+     * @test
+     */
+    public function it_handles_absent_extra_config_with_grace(): void
+    {
+
+        $badComposerJson = '{ "name": "coenjacobs/mozart" }';
+
+        file_put_contents(__DIR__ . '/composer.json', $badComposerJson);
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $outputInterfaceMock->expects($this->exactly(1))
+                            ->method('write');
+
+        $compose = new class( $inputInterfaceMock, $outputInterfaceMock ) extends Compose {
+            public function __construct($inputInterfaceMock, $outputInterfaceMock)
+            {
+                parent::__construct();
+
+                $this->execute($inputInterfaceMock, $outputInterfaceMock);
+            }
+        };
+    }
+
+
+    /**
+     * When composer.json->extra is not an object, instead of
+     * "Trying to get property 'mozart' of non-object"
+     * a better message should be written to the OutputInterface.
+     *
+     * @test
+     */
+    public function it_handles_malformed_extra_config_with_grace(): void
+    {
+
+        $badComposerJson = '{ "name": "coenjacobs/mozart", "extra": [] }';
+
+        file_put_contents(__DIR__ . '/composer.json', $badComposerJson);
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $outputInterfaceMock->expects($this->exactly(1))
+                            ->method('write');
+
+        $compose = new class( $inputInterfaceMock, $outputInterfaceMock ) extends Compose {
+            public function __construct($inputInterfaceMock, $outputInterfaceMock)
+            {
+                parent::__construct();
+
+                $this->execute($inputInterfaceMock, $outputInterfaceMock);
+            }
+        };
+    }
+
+    /**
+     * When composer.json->extra->mozart is absent, instead of
+     * "Undefined property: stdClass::$mozart"
+     * a better message should be written to the OutputInterface.
+     *
+     * @test
+     */
+    public function it_handles_absent_mozart_config_with_grace(): void
+    {
+
+        $badComposerJson = '{ "name": "coenjacobs/mozart", "extra": { "moozart": {} } }';
+
+        file_put_contents(__DIR__ . '/composer.json', $badComposerJson);
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $outputInterfaceMock->expects($this->exactly(1))
+                            ->method('write');
+
+        $compose = new class( $inputInterfaceMock, $outputInterfaceMock ) extends Compose {
+            public function __construct($inputInterfaceMock, $outputInterfaceMock)
+            {
+                parent::__construct();
+
+                $this->execute($inputInterfaceMock, $outputInterfaceMock);
+            }
+        };
+    }
+
+    /**
+     * When composer.json->extra->mozart is malformed, instead of
+     * "Undefined property: stdClass::$mozart"
+     * a better message should be written to the OutputInterface.
+     *
+     * is_object() added.
+     *
+     * @test
+     */
+    public function it_handles_malformed_mozart_config__with_grace(): void
+    {
+
+        $badComposerJson = '{ "name": "coenjacobs/mozart", "extra": { "mozart": [] } }';
+
+        file_put_contents(__DIR__ . '/composer.json', $badComposerJson);
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $outputInterfaceMock->expects($this->exactly(1))
+                            ->method('write');
+
+        $compose = new class( $inputInterfaceMock, $outputInterfaceMock ) extends Compose {
+            public function __construct($inputInterfaceMock, $outputInterfaceMock)
+            {
+                parent::__construct();
+
+                $this->execute($inputInterfaceMock, $outputInterfaceMock);
+            }
+        };
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $composer_json = __DIR__ . '/composer.json';
+        if (file_exists($composer_json)) {
+            unlink($composer_json);
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        chdir(self::$cwd);
+    }
+}


### PR DESCRIPTION
The previously merged default-packages PR #34  didn't work in the beta.

When that didn't work, I noticed couple of things: the parsing of the config didn't output a single line "missing packages key" and then the attempt to use the null object caused further verbose error messages.

Now it defaults to an empty array, prefers `composer->extra->mozart->packages` and falls back to `composer->require` if available.

The unit tests I wrote are only to check `composer.json` exists, is valid json, and has the `extra->mozart` keys as objects. It wasn't until I opened the PR I see how I could've put in a mock `Replacer` to fully test the changes. I should read a book on PHP!