### PR TITLE
Always put a .gitkeep file in the classmaps directory

### DIFF
--- a/src/Mover.php
+++ b/src/Mover.php
@@ -43,6 +43,7 @@ class Mover
         $this->filesystem->createDir($this->config->dep_directory);
         $this->filesystem->deleteDir($this->config->classmap_directory);
         $this->filesystem->createDir($this->config->classmap_directory);
+        $this->filesystem->put($this->config->classmap_directory . '/.gitkeep', '');
     }
 
     public function movePackage(Package $package)


### PR DESCRIPTION
This is the simplest fix for the issue. An empty `.gitkeep` file is a common pattern for "persist this empty directory".

fixes #51