### PR TITLE
Mover::deleteTargerDirs() to delete only subdirs it is about to write to

### DIFF
--- a/src/Composer/Autoload/Autoloader.php
+++ b/src/Composer/Autoload/Autoloader.php
@@ -4,5 +4,5 @@ namespace CoenJacobs\Mozart\Composer\Autoload;
 
 interface Autoloader
 {
-    public function processConfig($config);
+    public function processConfig($autoloadConfig);
 }

--- a/src/Composer/Autoload/Classmap.php
+++ b/src/Composer/Autoload/Classmap.php
@@ -10,9 +10,9 @@ class Classmap implements Autoloader
     /** @var array */
     public $paths = [];
 
-    public function processConfig($config)
+    public function processConfig($autoloadConfig)
     {
-        foreach ($config as $value) {
+        foreach ($autoloadConfig as $value) {
             if ('.php' == substr($value, '-4', 4)) {
                 array_push($this->files, $value);
             } else {

--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -7,12 +7,23 @@ abstract class NamespaceAutoloader implements Autoloader
     /** @var string */
     public $namespace = '';
 
-    /** @var array */
+    /**
+     * The subdir of the vendor/domain/package directory that contains the files for this autoloader type.
+     *
+     * e.g. src/
+     *
+     * @var string[]
+     */
     public $paths = [];
 
-    public function processConfig($config)
+    /**
+     * A package's composer.json config autoload key's value, where $key is `psr-1`|`psr-4`|`classmap`.
+     *
+     * @param $autoloadConfig
+     */
+    public function processConfig($autoloadConfig)
     {
-        foreach ($config as $key => $value) {
+        foreach ($autoloadConfig as $key => $value) {
             $this->namespace = $key;
             array_push($this->paths, $value);
         }

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -3,6 +3,7 @@
 namespace CoenJacobs\Mozart\Composer;
 
 use CoenJacobs\Mozart\Composer\Autoload\Autoloader;
+use stdClass;
 
 class Package
 {
@@ -12,12 +13,20 @@ class Package
     /** @var */
     public $config;
 
-    /** @var array */
+    /** @var Autoloader[] */
     public $autoloaders = [];
 
     /** @var array */
     public $dependencies = [];
 
+    /**
+     * Create a PHP object to represent a composer package.
+     *
+     * @param string $path The path to the vendor folder with the composer.json "name", i.e. the domain/package
+     *                     definition, which is the vendor subdir from where the package's composer.json should be read.
+     * @param stdClass $overrideAutoload Optional configuration to replace the package's own autoload definition with
+     *                                    another which Mozart can use.
+     */
     public function __construct($path, $overrideAutoload = null)
     {
         $this->path   = $path;
@@ -45,11 +54,11 @@ class Package
                 continue;
             }
 
-            $autoconfigs = (array)$this->config->autoload->$key;
+            $autoloadConfig = (array)$this->config->autoload->$key;
 
             /** @var $autoloader Autoloader */
             $autoloader = new $value();
-            $autoloader->processConfig($autoconfigs);
+            $autoloader->processConfig($autoloadConfig);
 
             array_push($this->autoloaders, $autoloader);
         }

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -62,9 +62,6 @@ class Compose extends Command
 
         $this->config = $config;
 
-        $this->mover = new Mover($workingDir, $config);
-        $this->replacer = new Replacer($workingDir, $config);
-
         $require = array();
         if (isset($config->packages) && is_array($config->packages)) {
             $require = $config->packages;
@@ -74,6 +71,10 @@ class Compose extends Command
 
         $packages = $this->findPackages($require);
 
+        $this->mover = new Mover($workingDir, $config);
+        $this->replacer = new Replacer($workingDir, $config);
+
+        $this->mover->deleteTargetDirs($packages);
         $this->movePackages($packages);
         $this->replacePackages($packages);
 
@@ -81,7 +82,7 @@ class Compose extends Command
             $this->replacer->replaceParentPackage($package, null);
         }
 
-	    $this->replacer->replaceParentClassesInDirectory( $this->config->classmap_directory );
+        $this->replacer->replaceParentClassesInDirectory($this->config->classmap_directory);
         
         return 0;
     }
@@ -93,8 +94,6 @@ class Compose extends Command
      */
     protected function movePackages($packages)
     {
-        $this->mover->deleteTargetDirs();
-
         foreach ($packages as $package) {
             $this->movePackage($package);
         }

--- a/tests/MoverTest.php
+++ b/tests/MoverTest.php
@@ -1,0 +1,167 @@
+<?php
+declare(strict_types=1);
+
+use CoenJacobs\Mozart\Composer\Package;
+use CoenJacobs\Mozart\Mover;
+use PHPUnit\Framework\TestCase;
+
+class MoverTest extends TestCase
+{
+
+    /**
+     * A temporary directory for creating and deleting files for these tests.
+     *
+     * @var string
+     */
+    protected $testsWorkingDir;
+
+    /**
+     * composer->extra->mozart settings
+     *
+     * @var stdClass
+     */
+    protected $config;
+
+    /**
+     * Set up a common settings object.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testsWorkingDir = __DIR__ . '/temptestdir';
+        if (!file_exists($this->testsWorkingDir)) {
+            mkdir($this->testsWorkingDir);
+        }
+        
+        $config = new class() {
+        };
+        $config->dep_directory = "/dep_directory/";
+        $config->classmap_directory = "/classmap_directory/";
+        $config->packages = array(
+                "pimple/pimple",
+                "ezyang/htmlpurifier"
+            );
+
+        $pimpleAutoload = json_decode("{ \"psr-0\" : { \"Pimple\" : [ \"src/\" ]  } }");
+        $htmlpurifierAutoload = json_decode("{ \"classmap\" : { \"Pimple\" => [ \"library/\" ]  } }");
+
+        $config->override_autoload = array();
+        $config->override_autoload["pimple/pimple"] = $pimpleAutoload;
+        $config->override_autoload["ezyang/htmlpurifier"] = $htmlpurifierAutoload;
+
+        $this->config = $config;
+    }
+
+    /**
+     * If the specified `dep_directory` or `classmap_directory` are absent, create them.
+     *
+     * @test
+     */
+    public function it_creates_absent_dirs(): void
+    {
+        $mover = new Mover($this->testsWorkingDir, $this->config);
+
+        $packages = array();
+
+        $mover->deleteTargetDirs($packages);
+
+        $this->assertTrue(file_exists($this->testsWorkingDir . DIRECTORY_SEPARATOR
+                                      . $this->config->dep_directory));
+        $this->assertTrue(file_exists($this->testsWorkingDir . DIRECTORY_SEPARATOR
+                                      . $this->config->classmap_directory));
+    }
+
+    /**
+     * If the specified `dep_directory` or `classmap_directory` already exists with contents, it is not an issue.
+     *
+     * @test
+     */
+    public function it_is_unpertrubed_by_existing_dirs(): void
+    {
+        $mover = new Mover($this->testsWorkingDir, $this->config);
+
+        if (!file_exists($this->testsWorkingDir . $this->config->dep_directory)) {
+            mkdir($this->testsWorkingDir . $this->config->dep_directory);
+        }
+        if (!file_exists($this->testsWorkingDir . $this->config->classmap_directory)) {
+            mkdir($this->testsWorkingDir . $this->config->classmap_directory);
+        }
+
+        $this->assertDirectoryExists($this->testsWorkingDir . $this->config->dep_directory);
+        $this->assertDirectoryExists($this->testsWorkingDir . $this->config->classmap_directory);
+  
+        $packages = array();
+
+        ob_start();
+
+        $mover->deleteTargetDirs($packages);
+
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    /**
+     * If the specified `dep_directory` or `classmap_directory` contains a subdir we are going to need when moving,
+     * delete the subdir. aka:  If subfolders exist for dependencies we are about to manage, delete those subfolders.
+     *
+     * @test
+     */
+    public function it_deletes_subdirs_for_packages_about_to_be_moved(): void
+    {
+        $mover = new Mover($this->testsWorkingDir, $this->config);
+
+        mkdir($this->testsWorkingDir  . DIRECTORY_SEPARATOR . $this->config->dep_directory);
+        mkdir($this->testsWorkingDir  . DIRECTORY_SEPARATOR . $this->config->classmap_directory);
+
+        // TODO: Create the subdirs that should be deleted.
+        mkdir($this->testsWorkingDir  . DIRECTORY_SEPARATOR . $this->config->dep_directory . 'Pimple');
+        mkdir($this->testsWorkingDir  . DIRECTORY_SEPARATOR . $this->config->classmap_directory . 'ezyang');
+
+        $packages = array();
+        foreach ($this->config->packages as $packageString) {
+            $testDummyComposerDir = $this->testsWorkingDir  . DIRECTORY_SEPARATOR . 'vendor'
+                                    . DIRECTORY_SEPARATOR . $packageString;
+            @mkdir($testDummyComposerDir, 0777, true);
+            $testDummyComposerPath = $testDummyComposerDir . DIRECTORY_SEPARATOR . 'composer.json';
+            $testDummyComposerContents = json_encode(new stdClass());
+
+            file_put_contents($testDummyComposerPath, $testDummyComposerContents);
+            $parsedPackage = new Package($testDummyComposerDir, $this->config->override_autoload[$packageString]);
+            $parsedPackage->findAutoloaders();
+            $packages[] = $parsedPackage;
+        }
+
+        $mover->deleteTargetDirs($packages);
+
+        $this->assertDirectoryNotExists($this->testsWorkingDir . $this->config->dep_directory . 'Pimple');
+        $this->assertDirectoryNotExists($this->testsWorkingDir . $this->config->dep_directory . 'ezyang');
+    }
+
+    /**
+     * Delete $this->testsWorkingDir after each test.
+     *
+     * @see https://stackoverflow.com/questions/3349753/delete-directory-with-files-in-it
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $dir = $this->testsWorkingDir;
+
+        $it = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS);
+        $files = new RecursiveIteratorIterator(
+            $it,
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getRealPath());
+            } else {
+                unlink($file->getRealPath());
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
Rather than deleting the entirety of the classmap_directory and dep_directory, this change scans the packages about to be moved and only deletes subdirectories about to be written to, allowing using the base of classmap_directory and dep_directory for other filies.

I think #51 and #52 were the wrong way to approach the stated problem. I think this accommodates the needs of #51 

I intend to write another PR to delete empty classmap_directory and dep_directory. 

This PR allows the user to place a .gitkeep in the directory (or any file at all) and it will not be deleted, while allowing the idea of deleting the directory if there is nothing in it.