### PR TITLE
Return one Autoloader per namespace

### DIFF
--- a/src/Composer/Autoload/Autoloader.php
+++ b/src/Composer/Autoload/Autoloader.php
@@ -4,5 +4,12 @@ namespace CoenJacobs\Mozart\Composer\Autoload;
 
 interface Autoloader
 {
-    public function processConfig($autoloadConfig);
+
+    /**
+     *
+     * @param $autoloadConfig A package's composer.json config autoload key's value, where $key is `psr-0`|`psr-4`|`classmap`.
+     *
+     * @return Autoloader[]
+     */
+    public static function processConfig($autoloadConfig);
 }

--- a/src/Composer/Autoload/Autoloader.php
+++ b/src/Composer/Autoload/Autoloader.php
@@ -7,12 +7,10 @@ interface Autoloader
 
     /**
      *
-     * @param $autoloadConfig A package's composer.json config autoload key's value, where $key is `psr-0`|`psr-4`|`classmap`.
+     * @param array $autoloadConfig A package's composer.json config autoload key's value,
+     *                                  where key is `psr-0`|`psr-4`|`classmap`.
      *
      * @return Autoloader[]
      */
-    public static function processConfig($autoloadConfig);
-
-    public function getSearchNamespace();
-
+    public static function processConfig($autoloadConfig): array;
 }

--- a/src/Composer/Autoload/Classmap.php
+++ b/src/Composer/Autoload/Classmap.php
@@ -10,14 +10,28 @@ class Classmap implements Autoloader
     /** @var array */
     public $paths = [];
 
-    public function processConfig($autoloadConfig)
+    public function __construct($files, $paths)
     {
+
+        $this->files = $files;
+        $this->paths = $paths;
+    }
+
+    public static function processConfig($autoloadConfig)
+    {
+        $files = array();
+        $paths = array();
+
         foreach ($autoloadConfig as $value) {
             if ('.php' == substr($value, '-4', 4)) {
-                array_push($this->files, $value);
+                array_push($files, $value);
             } else {
-                array_push($this->paths, $value);
+                array_push($paths, $value);
             }
         }
+
+        $classmapAutoloader = new self($files, $paths);
+
+        return [ $classmapAutoloader ] ;
     }
 }

--- a/src/Composer/Autoload/Classmap.php
+++ b/src/Composer/Autoload/Classmap.php
@@ -10,21 +10,25 @@ class Classmap implements Autoloader
     /** @var array */
     public $paths = [];
 
-
+    /**
+     * Classmap constructor.
+     *
+     * @param string[] $files Individual .php files specified in the classmap.
+     * @param string[] $paths Directory paths specified in the classmap.
+     */
     public function __construct($files, $paths)
     {
-
         $this->files = $files;
-        $this->paths = $paths;
+        $this->paths = array_merge($this->paths, $paths);
     }
 
-    public static function processConfig($autoloadConfig)
+    public static function processConfig($autoloadConfig): array
     {
         $files = array();
         $paths = array();
 
         foreach ($autoloadConfig as $value) {
-            if ('.php' == substr($value, '-4', 4)) {
+            if ('.php' == substr($value, -4, 4)) {
                 array_push($files, $value);
             } else {
                 array_push($paths, $value);
@@ -34,15 +38,5 @@ class Classmap implements Autoloader
         $classmapAutoloader = new self($files, $paths);
 
         return [ $classmapAutoloader ] ;
-    }
-
-    /**
-     * @throws \Exception
-     *
-     * @return void
-     */
-    public function getSearchNamespace()
-    {
-        throw new \Exception('Classmap autoloaders do not contain a namespace and this method can not be used.');
     }
 }

--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -16,17 +16,10 @@ abstract class NamespaceAutoloader implements Autoloader
      */
     public $paths = [];
 
-    /**
-     * A package's composer.json config autoload key's value, where $key is `psr-1`|`psr-4`|`classmap`.
-     *
-     * @param $autoloadConfig
-     */
-    public function processConfig($autoloadConfig)
+    public function __construct($namespace, $paths)
     {
-        foreach ($autoloadConfig as $key => $value) {
-            $this->namespace = $key;
-            array_push($this->paths, $value);
-        }
+        $this->namespace = $namespace;
+        array_push($this->paths, $paths);
     }
 
     public function getSearchNamespace()

--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -16,17 +16,22 @@ abstract class NamespaceAutoloader implements Autoloader
      */
     public $paths = [];
 
-
+    /**
+     * NamespaceAutoloader constructor.
+     *
+     * @param string $namespace
+     * @param string $paths
+     */
     public function __construct($namespace, $paths)
     {
         $this->namespace = $namespace;
-        array_push($this->paths, $paths);
+        $this->paths[] = $paths;
     }
 
     /**
      * @return string
      */
-    public function getSearchNamespace()
+    public function getSearchNamespace(): string
     {
         return $this->namespace;
     }

--- a/src/Composer/Autoload/Psr0.php
+++ b/src/Composer/Autoload/Psr0.php
@@ -4,7 +4,7 @@ namespace CoenJacobs\Mozart\Composer\Autoload;
 
 class Psr0 extends NamespaceAutoloader
 {
-    public static function processConfig($autoloadConfig)
+    public static function processConfig($autoloadConfig): array
     {
         $psr0s = array();
 

--- a/src/Composer/Autoload/Psr0.php
+++ b/src/Composer/Autoload/Psr0.php
@@ -4,4 +4,14 @@ namespace CoenJacobs\Mozart\Composer\Autoload;
 
 class Psr0 extends NamespaceAutoloader
 {
+    public static function processConfig($autoloadConfig)
+    {
+        $psr0s = array();
+
+        foreach ($autoloadConfig as $key => $value) {
+            $psr0s[] = new Psr0($key, $value);
+        }
+
+        return $psr0s;
+    }
 }

--- a/src/Composer/Autoload/Psr4.php
+++ b/src/Composer/Autoload/Psr4.php
@@ -13,4 +13,15 @@ class Psr4 extends NamespaceAutoloader
     {
         return str_replace('\\', '/', $this->namespace);
     }
+
+    public static function processConfig($autoloadConfig)
+    {
+        $autoloaders = array();
+
+        foreach ($autoloadConfig as $key => $value) {
+            $autoloaders[] = new self($key, $value);
+        }
+
+        return $autoloaders;
+    }
 }

--- a/src/Composer/Autoload/Psr4.php
+++ b/src/Composer/Autoload/Psr4.php
@@ -7,7 +7,7 @@ class Psr4 extends NamespaceAutoloader
     /**
      * @return string
      */
-    public function getSearchNamespace()
+    public function getSearchNamespace(): string
     {
         return trim($this->namespace, '\\');
     }
@@ -20,7 +20,7 @@ class Psr4 extends NamespaceAutoloader
         return str_replace('\\', DIRECTORY_SEPARATOR, $this->namespace);
     }
 
-    public static function processConfig($autoloadConfig)
+    public static function processConfig($autoloadConfig): array
     {
         $autoloaders = array();
 

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -10,7 +10,7 @@ class Package
     /** @var string */
     public $path = '';
 
-    /** @var */
+    /** @var stdClass */
     public $config;
 
     /** @var Autoloader[] */

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -56,11 +56,10 @@ class Package
 
             $autoloadConfig = (array)$this->config->autoload->$key;
 
-            /** @var $autoloader Autoloader */
-            $autoloader = new $value();
-            $autoloader->processConfig($autoloadConfig);
+            /** @var Autoloader[] */
+            $autoloaders = call_user_func(array( $value, 'processConfig' ), $autoloadConfig);
 
-            array_push($this->autoloaders, $autoloader);
+            $this->autoloaders = array_merge($this->autoloaders, $autoloaders);
         }
     }
 }

--- a/tests/Composer/PackageTest.php
+++ b/tests/Composer/PackageTest.php
@@ -1,0 +1,254 @@
+<?php
+declare(strict_types=1);
+
+use CoenJacobs\Mozart\Composer\Package;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class PackageTest
+ * @covers \CoenJacobs\Mozart\Composer\Package
+ */
+class PackageTest extends TestCase
+{
+
+    protected $testsWorkingDir;
+
+    /**
+     * Package currently reads a file in its constructor so we need to write the files first.
+     *
+     * Make a directory
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testsWorkingDir = __DIR__ . '/temptestdir';
+        if (!file_exists($this->testsWorkingDir)) {
+            mkdir($this->testsWorkingDir);
+        }
+    }
+
+    /**
+     * Delete $this->testsWorkingDir after each test.
+     *
+     * @see https://stackoverflow.com/questions/3349753/delete-directory-with-files-in-it
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $dir = $this->testsWorkingDir;
+
+        $it = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS);
+        $files = new RecursiveIteratorIterator(
+            $it,
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getRealPath());
+            } else {
+                unlink($file->getRealPath());
+            }
+        }
+        rmdir($dir);
+        chdir(__DIR__);
+    }
+
+    /**
+     * @covers \CoenJacobs\Mozart\Composer\Package::__construct
+     */
+    public function test_instantiation()
+    {
+
+        $composer  = <<<'EOD'
+{
+    "name": "mustache/mustache",
+    "autoload": {
+			"psr-0": { "Mustache": "src/" }
+    }
+}
+EOD;
+
+        $filename = $this->testsWorkingDir . '/composer.json';
+
+        file_put_contents($filename, $composer);
+
+        $package = new Package($this->testsWorkingDir);
+
+        $this->assertEquals($this->testsWorkingDir, $package->path);
+
+        $this->assertNotNull($package->config);
+    }
+
+
+    /**
+     * @covers \CoenJacobs\Mozart\Composer\Package::__construct
+     */
+    public function test_instantiation_override_autoload()
+    {
+
+        $composer  = <<<'EOD'
+{
+    "name": "google/apiclient",
+    "autoload": {
+        "psr-0": {
+            "Google_": "src/"
+        }
+    }
+}
+EOD;
+        $overrideAutoload = new stdClass();
+        $overrideAutoload->classmap = [  "src/Google/Service/"  ] ;
+
+        $filename = $this->testsWorkingDir . '/composer.json';
+
+        file_put_contents($filename, $composer);
+
+        $package = new Package($this->testsWorkingDir, $overrideAutoload);
+        $package->findAutoloaders();
+
+        $this->assertCount(1, $package->autoloaders);
+        $this->assertInstanceOf(\CoenJacobs\Mozart\Composer\Autoload\Classmap::class, $package->autoloaders[0]);
+    }
+
+
+    /**
+     * @covers \CoenJacobs\Mozart\Composer\Package::findAutoloaders
+     */
+    public function test_find_autoloaders_finds_psr_0()
+    {
+
+        $composer  = <<<'EOD'
+{
+    "name": "mustache/mustache",
+    "autoload": {
+			"psr-0": { "Mustache": "src/" }
+    }
+}
+EOD;
+
+        $filename = $this->testsWorkingDir . '/composer.json';
+
+        file_put_contents($filename, $composer);
+
+        $package = new Package($this->testsWorkingDir);
+        $package->findAutoloaders();
+
+        $this->assertCount(1, $package->autoloaders);
+
+        $this->assertInstanceOf(\CoenJacobs\Mozart\Composer\Autoload\Psr0::class, $package->autoloaders[0]);
+    }
+
+    /**
+     * @covers \CoenJacobs\Mozart\Composer\Package::findAutoloaders
+     */
+    public function test_find_autoloaders_finds_psr_4()
+    {
+
+        $composer  = <<<'EOD'
+{
+    "name": "psr/container",
+    "autoload": {
+        "psr-4": {
+            "Psr\\Container\\": "src/"
+        }
+    }
+}
+EOD;
+
+        $filename = $this->testsWorkingDir . '/composer.json';
+
+        file_put_contents($filename, $composer);
+
+        $package = new Package($this->testsWorkingDir);
+        $package->findAutoloaders();
+
+        $this->assertCount(1, $package->autoloaders);
+
+        $this->assertInstanceOf(\CoenJacobs\Mozart\Composer\Autoload\Psr4::class, $package->autoloaders[0]);
+    }
+
+    /**
+     * @covers \CoenJacobs\Mozart\Composer\Package::findAutoloaders
+     */
+    public function test_find_autoloaders_finds_classmap()
+    {
+
+        $composer  = <<<'EOD'
+{
+    "name": "iio/libmergepdf",
+    "autoload": {
+        "classmap": [
+            "tcpdi/"
+        ]
+    }
+}
+EOD;
+
+        $filename = $this->testsWorkingDir . '/composer.json';
+
+        file_put_contents($filename, $composer);
+
+        $package = new Package($this->testsWorkingDir);
+        $package->findAutoloaders();
+
+        $this->assertCount(1, $package->autoloaders);
+
+        $this->assertInstanceOf(\CoenJacobs\Mozart\Composer\Autoload\Classmap::class, $package->autoloaders[0]);
+    }
+
+    /**
+     * @covers \CoenJacobs\Mozart\Composer\Package::findAutoloaders
+     */
+    public function test_find_multiple_different_autoloaders()
+    {
+
+        $composer  = <<<'EOD'
+{
+    "name": "google/apiclient",
+    "autoload": {
+        "psr-0": {
+            "Google_": "src/"
+        },
+        "classmap": [
+            "src/Google/Service/"
+        ]
+    }
+}
+EOD;
+
+        $filename = $this->testsWorkingDir . '/composer.json';
+
+        file_put_contents($filename, $composer);
+
+        $package = new Package($this->testsWorkingDir);
+        $package->findAutoloaders();
+
+        $this->assertCount(2, $package->autoloaders);
+    }
+
+    public function test_find_multiple_same_autoloaders()  {
+
+	    $composer  = <<<'EOD'
+{
+    "name": "rubix/tensor",
+    "autoload": {
+        "psr-4": {
+            "Tensor\\": "src/",
+            "JAMA\\": "lib/JAMA"
+        }
+    }
+}
+EOD;
+
+	    $filename = $this->testsWorkingDir . '/composer.json';
+
+	    file_put_contents($filename, $composer);
+
+	    $package = new Package($this->testsWorkingDir);
+	    $package->findAutoloaders();
+
+	    $this->assertCount(2, $package->autoloaders);
+    }
+}

--- a/tests/MoverTest.php
+++ b/tests/MoverTest.php
@@ -46,7 +46,7 @@ class MoverTest extends TestCase
                 "ezyang/htmlpurifier"
             );
 
-        $pimpleAutoload = json_decode("{ \"psr-0\" : { \"Pimple\" : [ \"src/\" ]  } }");
+	    $pimpleAutoload = json_decode("{ \"psr-0\" : { \"Pimple\" : \"src/\"  } }");
         $htmlpurifierAutoload = json_decode("{ \"classmap\" : { \"Pimple\" => [ \"library/\" ]  } }");
 
         $config->override_autoload = array();

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -5,6 +5,10 @@ use CoenJacobs\Mozart\Composer\Autoload\Psr0;
 use CoenJacobs\Mozart\Replace\NamespaceReplacer;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class NamespaceReplacerTest
+ * @covers \CoenJacobs\Mozart\Replace\NamespaceReplacer
+ */
 class NamespaceReplacerTest extends TestCase
 {
     const PREFIX = 'My\\Mozart\\Prefix\\';
@@ -27,10 +31,12 @@ class NamespaceReplacerTest extends TestCase
      */
     protected static function createReplacer(string $namespace, string $prefix = self::PREFIX) : NamespaceReplacer
     {
-        $autoloader = new Psr0;
-        $autoloader->namespace = $namespace;
+
+    	$psr0Key = json_decode( '{"Google_": "src/"}' );
+        $autoloader = Psr0::processConfig($psr0Key);
+        $autoloader[0]->namespace = $namespace;
         $replacer = new NamespaceReplacer();
-        $replacer->setAutoloader($autoloader);
+        $replacer->setAutoloader($autoloader[0]);
         $replacer->dep_namespace = $prefix;
 
         return $replacer;


### PR DESCRIPTION
When a composer.json's autoload key contains two namespaces, return two Autoloader objects. e.g. RubixML/Tensor

https://github.com/RubixML/Tensor/blob/86bb628781f311684a6778744a22b283efdae58f/composer.json#L36-L39