### PR TITLE
Skip files when the destination already exists.

### DIFF
--- a/src/Mover.php
+++ b/src/Mover.php
@@ -184,10 +184,12 @@ class Mover
             $targetFile = str_replace($packageVendorPath, DIRECTORY_SEPARATOR, $targetFile);
         }
 
-        $this->filesystem->copy(
-            str_replace($this->workingDir, '', $file->getPathname()),
-            $targetFile
-        );
+        if (!$this->filesystem->has($targetFile)) {
+            $this->filesystem->copy(
+                str_replace($this->workingDir, '', $file->getPathname()),
+                $targetFile
+            );
+        }
 
         return $targetFile;
     }


### PR DESCRIPTION
I've found an issue where two different packages (one a subpackage of the other) use the same PSR-4 namespace, so Mozart copies them into the same folder, and I get an error "File Already Exists" for `LICENSE.md`.

Reproduce with:

```
{
  "require": {
    "illuminate/support": "^8.0"
  },
  "require-dev": {
    "coenjacobs/mozart": "dev-master"
  },
  "extra": {
    "mozart": {
      "dep_namespace": "Project_Name\\",
      "dep_directory": "/src/vendor/",
      "classmap_prefix": "Project_Name_",
      "classmap_directory": "/src/dependencies/",
      "delete_vendor_directories": false
    }
  },
  "scripts": {
    "post-install-cmd": [
      "\"vendor/bin/mozart\" compose"
    ],
    "post-update-cmd": [
      "\"vendor/bin/mozart\" compose"
    ]
  }
}
```

Gives error:

```
In Filesystem.php line 405:
                                                                         
  File already exists at path: src/vendor/Illuminate/Support/LICENSE.md  
```

Presumably caused by:

```
{
    "name": "illuminate/support",
...
    "require": {
...
        "illuminate/macroable": "^8.0",
...
    },
...
    "autoload": {
        "psr-4": {
            "Illuminate\\Support\\": ""
        },
```

```
{
    "name": "illuminate/macroable",
...
    "autoload": {
        "psr-4": {
            "Illuminate\\Support\\": ""
        }
```

So I fixed it by checking does the file already exist in place. This doesn't feel entirely robust. 

This would be nice with an output message showing severity, i.e. txt and md aren't as important as php. Files could be compared to see if it's the same file which is already in place. Mover doesn't have an instance of `$output` though.


Applying the patch with the following composer.json shows it working:

```
{
  "require": {
    "illuminate/support": "^8.0"
  },
  "require-dev": {
    "coenjacobs/mozart": "dev-master",
    "cweagans/composer-patches": "~1.0"
  },
  "extra": {
    "patches": {
      "coenjacobs/mozart": {
        "Skip files when the destination already exists": "https://github.com/coenjacobs/mozart/pull/65.patch"
      }
    },
    "mozart": {
      "dep_namespace": "Project_Name\\",
      "dep_directory": "/src/vendor/",
      "classmap_prefix": "Project_Name_",
      "classmap_directory": "/src/dependencies/",
      "delete_vendor_directories": false
    }
  },
  "scripts": {
    "post-install-cmd": [
      "\"vendor/bin/mozart\" compose"
    ],
    "post-update-cmd": [
      "\"vendor/bin/mozart\" compose"
    ]
  }
}
```

I see besides `LICENSE.md`, `composer.json` is another file being skipped. It might be a good idea to prefix/suffix the file with the package name so neither are lost.