### PR TITLE
Limit replacements to the beginning of the namespace string

### DIFF
--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -12,7 +12,8 @@ class NamespaceReplacer extends BaseReplacer
         $searchNamespace = preg_quote($this->autoloader->getSearchNamespace(), '/');
         $dependencyNamespace = preg_quote($this->dep_namespace, '/');
 
-        return preg_replace_callback("
+        return preg_replace_callback(
+            "
             /                                # Start the pattern
               ([^a-zA-Z0-9_\x7f-\xff])       # Match the non-class character before the namespace
                 (                            # Start the namespace matcher

--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -9,11 +9,19 @@ class NamespaceReplacer extends BaseReplacer
 
     public function replace($contents)
     {
-        $searchNamespace = addslashes($this->autoloader->getSearchNamespace());
-        $dependencyNamespace = addslashes($this->dep_namespace);
+        $searchNamespace = preg_quote($this->autoloader->getSearchNamespace(), '/');
+        $dependencyNamespace = preg_quote($this->dep_namespace, '/');
 
-        return preg_replace_callback(
-            '/([^a-zA-Z0-9_\x7f-\xff])((?<!' . $dependencyNamespace . ')' . $searchNamespace . '[\\\|;])/U',
+        return preg_replace_callback("
+            /                                # Start the pattern
+              ([^a-zA-Z0-9_\x7f-\xff])       # Match the non-class character before the namespace
+                (                            # Start the namespace matcher
+                  (?<!$dependencyNamespace)  # Does NOT start with the prefix
+                  (?<![a-zA-Z0-9_]\\\\)      # Not a class-allowed character followed by a slash
+                  $searchNamespace           # The namespace we're looking for
+                  [\\\|;]                    # Backslash, semicolon, or pipe
+                )                            # End the namespace matcher
+            /Ux",
             function ($matches) {
                 return $matches[1] . $this->dep_namespace . $matches[2];
             },

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -93,5 +93,15 @@ class NamespaceReplacerTest extends TestCase
 
         // Then, we test that chickenReplacer(eggReplacer()) yields the expected result.
         $this->assertEquals($expected, $chickenReplacer->replace($eggReplacer->replace($contents)));
+
+        // Now we do the same thing, but with root-relative references.
+        $contents = 'use \\Chicken\\Egg;';
+        $expected = 'use \\My\\Mozart\\Prefix\\Chicken\\Egg;';
+
+        // First, we test that eggReplacer(chickenReplacer()) yields the expected result.
+        $this->assertEquals($expected, $eggReplacer->replace($chickenReplacer->replace($contents)));
+
+        // Then, we test that chickenReplacer(eggReplacer()) yields the expected result.
+        $this->assertEquals($expected, $chickenReplacer->replace($eggReplacer->replace($contents)));
     }
 }

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -7,12 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 class NamespaceReplacerTest extends TestCase
 {
+    const PREFIX = 'My\\Mozart\\Prefix\\';
+
     /** @var NamespaceReplacer */
     public $replacer;
 
     protected function setUp(): void
     {
-        $this->replacer = self::createReplacer('Test\\Test', 'Prefix\\');
+        $this->replacer = self::createReplacer('Test\\Test');
     }
 
     /**
@@ -23,7 +25,7 @@ class NamespaceReplacerTest extends TestCase
      *
      * @return Psr0
      */
-    protected static function createReplacer(string $namespace, string $prefix) : NamespaceReplacer
+    protected static function createReplacer(string $namespace, string $prefix = self::PREFIX) : NamespaceReplacer
     {
         $autoloader = new Psr0;
         $autoloader->namespace = $namespace;
@@ -40,19 +42,19 @@ class NamespaceReplacerTest extends TestCase
         $contents = 'namespace Test\\Test;';
         $contents = $this->replacer->replace($contents);
 
-        $this->assertEquals('namespace Prefix\\Test\\Test;', $contents);
+        $this->assertEquals('namespace My\\Mozart\\Prefix\\Test\\Test;', $contents);
     }
 
 
     /** @test */
     public function it_doesnt_replaces_namespace_inside_namespace(): void
     {
-        $replacer = self::createReplacer('Test', 'Prefix\\');
+        $replacer = self::createReplacer('Test');
 
         $contents = "namespace Test\\Something;\n\nuse Test\\Test;";
         $contents = $replacer->replace($contents);
 
-        $this->assertEquals("namespace Prefix\\Test\\Something;\n\nuse Prefix\\Test\\Test;", $contents);
+        $this->assertEquals("namespace My\\Mozart\\Prefix\\Test\\Something;\n\nuse My\\Mozart\\Prefix\\Test\\Test;", $contents);
     }
 
     /** @test */
@@ -61,17 +63,17 @@ class NamespaceReplacerTest extends TestCase
         $contents = 'namespace Test\\Test\\Another;';
         $contents = $this->replacer->replace($contents);
 
-        $this->assertEquals('namespace Prefix\\Test\\Test\\Another;', $contents);
+        $this->assertEquals('namespace My\\Mozart\\Prefix\\Test\\Test\\Another;', $contents);
     }
 
 	/** @test */
     public function it_doesnt_prefix_already_prefixed_namespace(): void
     {
-        $replacer = self::createReplacer('Test\\Another', 'Prefix\\');
+        $replacer = self::createReplacer('Test\\Another');
 
-        $contents = 'namespace Prefix\\Test\\Another;';
+        $contents = 'namespace My\\Mozart\\Prefix\\Test\\Another;';
         $contents = $replacer->replace($contents);
 
-        $this->assertEquals('namespace Prefix\\Test\\Another;', $contents);
+        $this->assertEquals('namespace My\\Mozart\\Prefix\\Test\\Another;', $contents);
     }
 }

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -76,4 +76,22 @@ class NamespaceReplacerTest extends TestCase
 
         $this->assertEquals('namespace My\\Mozart\\Prefix\\Test\\Another;', $contents);
     }
+
+    /** @test */
+    public function it_doesnt_double_replace_namespaces_that_also_exist_inside_another_namespace(): void
+    {
+        $chickenReplacer = self::createReplacer('Chicken');
+        $eggReplacer = self::createReplacer('Egg');
+
+        // This is a tricky situation. We are referencing Chicken\Egg,
+        // but Egg *also* exists as a separate top level class.
+        $contents = 'use Chicken\\Egg;';
+        $expected = 'use My\\Mozart\\Prefix\\Chicken\\Egg;';
+
+        // First, we test that eggReplacer(chickenReplacer()) yields the expected result.
+        $this->assertEquals($expected, $eggReplacer->replace($chickenReplacer->replace($contents)));
+
+        // Then, we test that chickenReplacer(eggReplacer()) yields the expected result.
+        $this->assertEquals($expected, $chickenReplacer->replace($eggReplacer->replace($contents)));
+    }
 }


### PR DESCRIPTION
The namespace replacements regex was too permissive, and was replacing target namespaces even if they existed in the middle of a namespace string. This fixes that.

I should note that although I added tests, I don't have super high confidence that this fix doesn't break something else, because there are very few tests overall, and manipulating PHP code with regex is like doing surgery with a chainsaw.

fixes #67 
closes #68