### PR TITLE
GitHub Actions annotations for PHPUnit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-suggest --no-progress
       - name: Run tests
-        run: composer run test
+        run: vendor/bin/phpunit --printer mheap\\GithubActionsReporter\\Printer
   lint:
     runs-on: ubuntu-latest
     name: Lint project files

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "mheap/phpunit-github-actions-printer": "^1.4"
     },
     "scripts": {
         "lint": [


### PR DESCRIPTION
Uses [mheap/phpunit-github-actions-printer](https://github.com/mheap/phpunit-github-actions-printer) to add annotations to GitHub PRs' "files changed" and to the Actions' reports for PHPUnit failures.

Note that GitHub Actions tests will no longer use the "test" script defined in composer.json – we want to keep the regular report on local machines and just use annotations on GitHub. 

Encouraged by #70