### PR TITLE
Add a mechanism to exclude packages from processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Mozart requires little configuration. All you need to do is tell it where the bu
         "packages": [
             "pimple/pimple"
         ],
+        "exclude_packages": [
+            "psr/container"
+        ],
         "override_autoload": {
             "google/apiclient": {
                 "classmap": [
@@ -52,6 +55,7 @@ The following configuration is optional:
 
 - `delete_vendor_directories` is a boolean flag to indicate if the packages' vendor directories should be deleted after being processed. _default: true_.
 - `packages` is an optional array that defines the packages to be processed by Mozart. The array requires the slugs of packages in the same format as provided in your `composer.json`. Mozart will automatically rewrite dependencies of these packages as well. You don't need to add dependencies of these packages to the list. If this field is absent, all packages listed under composer require will be included.
+- `exclude_packages` is an optional array that defines the packages to be excluded from the processing performed by Mozart. This is useful if some of the packages in the `packages` array define dependent packages whose namespaces you want to keep unchanged. The array requires the slugs of the packages, as in the case of the `packages` array.
 - `override_autoload` a dictionary, keyed with the package names, of autoload settings to replace those in the original packages' `composer.json` `autoload` property.
 
 After Composer has loaded the packages as defined in your `composer.json` file, you can now run `mozart compose` and Mozart will bundle your packages according to the above configuration. It is recommended to dump the autoloader after Mozart has finished running, in case there are new classes or namespaces generated that aren't included in the autoloader yet. 

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -69,7 +69,14 @@ class Compose extends Command
             $require = array_keys(get_object_vars($composer->require));
         }
 
-        $packages = $this->findPackages($require);
+        $packagesByName = $this->findPackages($require);
+        $excludedPackagesNames = isset($config->excluded_packages) ? $config->excluded_packages : [];
+        $packagesToMoveByName = array_diff_key($packagesByName, array_flip($excludedPackagesNames));
+        $packages = array_values($packagesToMoveByName);
+
+        foreach ($packages as $package) {
+            $package->dependencies = array_diff_key($package->dependencies, array_flip($excludedPackagesNames));
+        }
 
         $this->mover = new Mover($workingDir, $config);
         $this->replacer = new Replacer($workingDir, $config);
@@ -173,7 +180,7 @@ class Compose extends Command
             }
 
             $package->dependencies = $this->findPackages($dependencies);
-            $packages[] = $package;
+            $packages[$package_slug] = $package;
         }
 
         return $packages;


### PR DESCRIPTION
Here we add an optional `excluded_packages` configuration key, which is an array of package slugs. Any package included here won't be processed by Mozart: it won't have its namepsaced changed and won't be moved from its original location. Namespace references to these packages won't be changed either.

This is useful if there are dependent packages whose namespace shouldn't be changed, for examle `psr/container`. Example `composer.json`:

```json
{
    ...
    "extra": {
        "mozart": {
        ...
            "packages": [
                "league/container"
            ],
            "excluded_packages":[
                "psr/container"
            ]
        }
    }
}
```

Note that this pull request is similar in intent to [the one to skip namespaces by leoloso](https://github.com/coenjacobs/mozart/pull/36), but in this case we are excluding whole packages, not namespaces.