### PR TITLE
Delete empty vendor directories after deleting package directories

### DIFF
--- a/src/Mover.php
+++ b/src/Mover.php
@@ -147,7 +147,9 @@ class Mover
                 }
             }
 
-            $this->movedPackages[] = $package->config->name;
+            if (!in_array($package->config->name, $this->movedPackages)) {
+                $this->movedPackages[] = $package->config->name;
+            }
         }
 
         if (!isset($this->config->delete_vendor_directories) || $this->config->delete_vendor_directories === true) {
@@ -200,11 +202,25 @@ class Mover
     protected function deletePackageVendorDirectories()
     {
         foreach ($this->movedPackages as $movedPackage) {
-            $packageDir = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . $movedPackage;
-            if (is_link($packageDir)) {
+            $packageDir = 'vendor' . DIRECTORY_SEPARATOR . $movedPackage;
+            if (!is_dir($packageDir) || is_link($packageDir)) {
                 continue;
             }
+
             $this->filesystem->deleteDir($packageDir);
+
+            //Delete parent directory too if it became empty
+            //(because that package was the only one from that vendor)
+            $parentDir = dirname($packageDir);
+            if ($this->dirIsEmpty($parentDir)) {
+                $this->filesystem->deleteDir($parentDir);
+            }
         }
+    }
+
+    private function dirIsEmpty($dir)
+    {
+        $di = new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS);
+        return iterator_count($di) === 0;
     }
 }


### PR DESCRIPTION
If `delete_vendor_directories` is set to `true` and all the packages from a given vendor are deleted, the directory having the vendor name inside `vendor` will still exist and be empty. This pull request checks if that's the case and then deletes the (now useless) empty
vendor directory.

Also, `is_link` in `deletePackageVendorDirectories` was mistakenly using the relative package directory prepended with `/`, so it was being interpreted as absolute. This pull request fixes that too.