### PR TITLE
Added DIRECTORY_SEPARATOR to workingDir

### DIFF
--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -35,7 +35,7 @@ class Compose extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $workingDir = getcwd();
-        $this->workingDir = $workingDir;
+        $this->workingDir = DIRECTORY_SEPARATOR;
 
         $composerFile = $workingDir . DIRECTORY_SEPARATOR. 'composer.json';
         if (!file_exists($composerFile)) {


### PR DESCRIPTION
THis fix is further developed from this issue:

https://github.com/coenjacobs/mozart/issues/43

THis now appears to fix Mozart in Windows