### PR TITLE
Replace parent packages over full tree of dependencies

### DIFF
--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -218,8 +218,9 @@ class Compose extends Command
             /** @var Package $dependency */
             foreach ($dependencies as $dependency) {
                 $this->replacer->replaceParentPackage($dependency, $package);
-                $this->replaceParentInTree($dependency->dependencies);
             }
+
+            $this->replaceParentInTree($package->dependencies);
         }
     }
 }

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -84,13 +84,9 @@ class Compose extends Command
         $this->mover->deleteTargetDirs($packages);
         $this->movePackages($packages);
         $this->replacePackages($packages);
-
-        foreach ($packages as $package) {
-            $this->replacer->replaceParentPackage($package, null);
-        }
-
+        $this->replaceParentInTree($packages);
         $this->replacer->replaceParentClassesInDirectory($this->config->classmap_directory);
-        
+
         return 0;
     }
 

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -185,4 +185,45 @@ class Compose extends Command
 
         return $packages;
     }
+
+    /**
+     * Get an array containing all the dependencies and dependencies
+     * @param Package $package
+     * @param array   $dependencies
+     * @return array
+     */
+    private function getAllDependenciesOfPackage(Package $package, $dependencies = []): array
+    {
+        if (empty($package->dependencies)) {
+            return $dependencies;
+        }
+
+        /** @var Package $dependency */
+        foreach ($package->dependencies as $dependency) {
+            $dependencies[] = $dependency;
+        }
+
+        foreach ($package->dependencies as $dependency) {
+            $dependencies = $this->getAllDependenciesOfPackage($dependency, $dependencies);
+        }
+
+        return $dependencies;
+    }
+
+    /**
+     * @param array $packages
+     */
+    private function replaceParentInTree(array $packages): void
+    {
+        /** @var Package $package */
+        foreach ($packages as $package) {
+            $dependencies = $this->getAllDependenciesOfPackage($package);
+
+            /** @var Package $dependency */
+            foreach ($dependencies as $dependency) {
+                $this->replacer->replaceParentPackage($dependency, $package);
+                $this->replaceParentInTree($dependency->dependencies);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Previous versions of Mozart used to only replace direct parent/child relationships between packages, while the grandchild (and so on, virtual unlimited number of layers deep) relationships were ignored. Say _package A_ relies on _package B_, while _package B_ relies on _package C_. Classes that were replaced in _C_ were only also replaced by reference in _B_ and not in _A_.  This PR fixes that, by looking at every single package and their full set of dependencies, looping through the available level of dependencies (and their dependencies and so on...) and processing each of them.

Not entirely happy with it, mainly the seemingly duplicate functionality in `private function findPackages($slugs)` that is now also covered by `private function getAllDependenciesOfPackage(Package $package, $dependencies = []): array`, where one works with slugs and the other one actually depends on those `->dependencies` property being set already on a `Package`. This might need some trimming, but this works as a proof of concept for now.

Fixes #58 and #80.