### PR TITLE
exclude_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 .DS_Store
 composer.lock
 .phpunit.result.cache
+tests/reports

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Mozart requires little configuration. All you need to do is tell it where the bu
         "exclude_packages": [
             "psr/container"
         ],
-        "exclude_files": [
+        "exclude_files_from_copy": [
             "/\\.md$/"
         ],
         "override_autoload": {
@@ -59,7 +59,7 @@ The following configuration is optional:
 - `delete_vendor_directories` is a boolean flag to indicate if the packages' vendor directories should be deleted after being processed. _default: true_.
 - `packages` is an optional array that defines the packages to be processed by Mozart. The array requires the slugs of packages in the same format as provided in your `composer.json`. Mozart will automatically rewrite dependencies of these packages as well. You don't need to add dependencies of these packages to the list. If this field is absent, all packages listed under composer require will be included.
 - `exclude_packages` is an optional array that defines the packages to be excluded from the processing performed by Mozart. This is useful if some of the packages in the `packages` array define dependent packages whose namespaces you want to keep unchanged. The array requires the slugs of the packages, as in the case of the `packages` array.
-- `exclude_files` is an optional array of regex patterns to check filenames against (including the path) where Mozart will skip that file if there is a match.
+- `exclude_files_from_copy` is an optional array of regex patterns to check filenames against (including the path) where Mozart will skip that file if there is a match.
 - `override_autoload` a dictionary, keyed with the package names, of autoload settings to replace those in the original packages' `composer.json` `autoload` property.
 
 After Composer has loaded the packages as defined in your `composer.json` file, you can now run `mozart compose` and Mozart will bundle your packages according to the above configuration. It is recommended to dump the autoloader after Mozart has finished running, in case there are new classes or namespaces generated that aren't included in the autoloader yet. 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Mozart requires little configuration. All you need to do is tell it where the bu
         "exclude_packages": [
             "psr/container"
         ],
+        "exclude_files": [
+            "/\\.md$/"
+        ],
         "override_autoload": {
             "google/apiclient": {
                 "classmap": [
@@ -56,6 +59,7 @@ The following configuration is optional:
 - `delete_vendor_directories` is a boolean flag to indicate if the packages' vendor directories should be deleted after being processed. _default: true_.
 - `packages` is an optional array that defines the packages to be processed by Mozart. The array requires the slugs of packages in the same format as provided in your `composer.json`. Mozart will automatically rewrite dependencies of these packages as well. You don't need to add dependencies of these packages to the list. If this field is absent, all packages listed under composer require will be included.
 - `exclude_packages` is an optional array that defines the packages to be excluded from the processing performed by Mozart. This is useful if some of the packages in the `packages` array define dependent packages whose namespaces you want to keep unchanged. The array requires the slugs of the packages, as in the case of the `packages` array.
+- `exclude_files` is an optional array of regex patterns to check filenames against (including the path) where Mozart will skip that file if there is a match.
 - `override_autoload` a dictionary, keyed with the package names, of autoload settings to replace those in the original packages' `composer.json` `autoload` property.
 
 After Composer has loaded the packages as defined in your `composer.json` file, you can now run `mozart compose` and Mozart will bundle your packages according to the above configuration. It is recommended to dump the autoloader after Mozart has finished running, in case there are new classes or namespaces generated that aren't included in the autoloader yet. 

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -60,8 +60,8 @@ class Compose extends Command
 
         $config->dep_namespace = preg_replace("/\\\{2,}$/", "\\", "$config->dep_namespace\\");
 
-        if (!isset($config->exclude_files)) {
-            $config->exclude_files = [];
+        if (!isset($config->exclude_files_from_copy)) {
+            $config->exclude_files_from_copy = [];
         }
 
         $this->config = $config;

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -60,6 +60,10 @@ class Compose extends Command
 
         $config->dep_namespace = preg_replace("/\\\{2,}$/", "\\", "$config->dep_namespace\\");
 
+        if (!isset($config->exclude_files)) {
+            $config->exclude_files = [];
+        }
+
         $this->config = $config;
 
         $require = array();

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -117,6 +117,12 @@ class Mover
                     $finder->files()->in($source_path);
 
                     foreach ($finder as $file) {
+                        foreach ($this->config->exclude_files as $file_exclusion_pattern) {
+                            if (1 === preg_match($file_exclusion_pattern, $file->getRealPath())) {
+                                continue 2;
+                            }
+                        }
+
                         $this->moveFile($package, $autoloader, $file, $path);
                     }
                 }

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -117,7 +117,7 @@ class Mover
                     $finder->files()->in($source_path);
 
                     foreach ($finder as $file) {
-                        foreach ($this->config->exclude_files as $file_exclusion_pattern) {
+                        foreach ($this->config->exclude_files_from_copy as $file_exclusion_pattern) {
                             if (1 === preg_match($file_exclusion_pattern, $file->getRealPath())) {
                                 continue 2;
                             }


### PR DESCRIPTION
Add a config option to exclude files based on regex match.

Problem encountered because [illuminate/collections](https://github.com/illuminate/collections)'s namespace is `Illuminate\Support`! 

```
{
    "name": "illuminate/collections",
...
    "autoload": {
        "psr-4": {
            "Illuminate\\Support\\": ""
        },
        "files": [
            "helpers.php"
        ]
    },
```

When I try to use both it and actual `illuminate/support` I get errors because Mozart is using the namespace to choose the target folder, not the package name.

```
File already exists at path: src/vendor/Illuminate/Support/LICENSE.md  
File already exists at path: src/vendor/Illuminate/Support/composer.json  
```

So I wrote some code to exclude them but then got:

```
File already exists at path: src/vendor/Illuminate/Support/helpers.php
```

The two `helpers.php` are not the same. But they're not being PSR-4 auto-loaded anyway, so I excluded it and Mozart does not complain.


Broken:

```
{
  "name": "brianhenryie/mozart-illuminate-file-clash",
  "require": {
    "illuminate/support": "^8.0",
    "illuminate/collections": "^8.0"
  },
  "require-dev": {
    "coenjacobs/mozart": "dev-master"
  },
  "extra": {
    "mozart": {
      "dep_namespace": "BH\\",
      "dep_directory": "/src/vendor/",
      "classmap_directory": "/src/classes/",
      "classmap_prefix": "BH_",
      "delete_vendor_directories": false
    }
  },
  "scripts": {
    "post-install-cmd": [
      "vendor/bin/mozart compose"
    ],
    "post-update-cmd": [
      "vendor/bin/mozart compose"
    ]
  }
}
```

working:

```
{
  "name": "brianhenryie/mozart-illuminate-file-clash",
  "require": {
    "illuminate/support": "^8.0",
    "illuminate/collections": "^8.0"
  },
  "require-dev": {
    "coenjacobs/mozart": "dev-master",
    "cweagans/composer-patches": "~1.0"
  },
  "extra": {
    "patches": {
      "coenjacobs/mozart": {
        "Exclude Files": "https://github.com/coenjacobs/mozart/pull/83.patch"
      }
    },
    "mozart": {
      "dep_namespace": "BH\\",
      "dep_directory": "/src/vendor/",
      "classmap_directory": "/src/classes/",
      "classmap_prefix": "BH_",
      "delete_vendor_directories": false,
      "exclude_files": ["/\\.md$/","/composer\\.json/","/helpers\\.php/"]
    }
  },
  "scripts": {
    "post-install-cmd": [
      "vendor/bin/mozart compose"
    ],
    "post-update-cmd": [
      "vendor/bin/mozart compose"
    ]
  }
}
```