### PR TITLE
Allow a space after the namespace we're searching for

### DIFF
--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -4,10 +4,20 @@ namespace CoenJacobs\Mozart\Replace;
 
 class NamespaceReplacer extends BaseReplacer
 {
-    /** @var string */
+    /**
+     * The prefix to add to existing namespaces.
+     *
+     * @var string "My\Mozart\Prefix".
+     */
     public $dep_namespace = '';
 
-    public function replace($contents)
+    /**
+     * @param string $contents The text to make replacements in.
+     * @param null $file Only used in ClassmapReplacer (for recording which files were changed).
+     *
+     * @return string The updated text.
+     */
+    public function replace($contents, $file = null)
     {
         $searchNamespace = preg_quote($this->autoloader->getSearchNamespace(), '/');
         $dependencyNamespace = preg_quote($this->dep_namespace, '/');
@@ -20,7 +30,7 @@ class NamespaceReplacer extends BaseReplacer
                   (?<!$dependencyNamespace)  # Does NOT start with the prefix
                   (?<![a-zA-Z0-9_]\\\\)      # Not a class-allowed character followed by a slash
                   $searchNamespace           # The namespace we're looking for
-                  [\\\|;]                    # Backslash, semicolon, or pipe
+                  [\\\|;\s]                  # Backslash, pipe, semicolon, or space
                 )                            # End the namespace matcher
             /Ux",
             function ($matches) {

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -104,4 +104,23 @@ class NamespaceReplacerTest extends TestCase
         // Then, we test that chickenReplacer(eggReplacer()) yields the expected result.
         $this->assertEquals($expected, $chickenReplacer->replace($eggReplacer->replace($contents)));
     }
+
+    /**
+     * @see https://github.com/coenjacobs/mozart/issues/75
+     *
+     * @test
+     */
+    public function it_replaces_namespace_use_as_declarations(): void
+    {
+
+        $namespace = 'Symfony\Polyfill\Mbstring';
+        $prefix = "MBViews\\Dependencies\\";
+
+        $replacer = self::createReplacer($namespace, $prefix);
+
+        $contents = "use Symfony\Polyfill\Mbstring as p;";
+        $expected = "use MBViews\Dependencies\Symfony\Polyfill\Mbstring as p;";
+
+        $this->assertEquals($expected, $replacer->replace($contents));
+    }
 }


### PR DESCRIPTION
Fix for #75. Edits @markjaquith 's regex to add `\s`. I think it's a safe change. Test added and existing `NamespaceReplacerTest`s all pass.