### PR TITLE
Improve ClassmapReplacer prefixing

### DIFF
--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -13,7 +13,7 @@ class ClassmapReplacer extends BaseReplacer
     public function replace($contents)
     {
         return preg_replace_callback(
-            '/(?:[abstract]*class |interface )([a-zA-Z\_]+)(?:[ \n]*{| extends| implements)/U',
+            '/(?:[abstract]*class |interface )([a-zA-Z0-9_\x7f-\xff]+)\s?(?:\n*|{| extends| implements)/',
             function ($matches) {
                 $replace = $this->classmap_prefix . $matches[1];
                 $this->saveReplacedClass($matches[1], $replace);

--- a/tests/replacers/ClassMapReplacerTest.php
+++ b/tests/replacers/ClassMapReplacerTest.php
@@ -75,4 +75,18 @@ class ClassMapReplacerTest extends TestCase
         $contents = $replacer->replace($contents);
         $this->assertEquals("class Mozart_Hello_World\n{", $contents);
     }
+
+    /**
+     * @see https://github.com/coenjacobs/mozart/issues/81
+     *
+     * @test
+     */
+    public function it_replaces_class(): void
+    {
+        $contents = "class Hello_World";
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $contents = $replacer->replace($contents);
+        $this->assertEquals("class Mozart_Hello_World", $contents);
+    }
 }


### PR DESCRIPTION
Bugfix for #81. Fixes the class prefixing of `pear/net_url2`.