### PR TITLE
Move each file only once (classmap) Fixes #89

### DIFF
--- a/src/Mover.php
+++ b/src/Mover.php
@@ -123,13 +123,16 @@ class Mover
             } elseif ($autoloader instanceof Classmap) {
                 $finder = new Finder();
 
+                $files_to_move = array();
+
                 foreach ($autoloader->files as $file) {
                     $source_path = $this->workingDir . DIRECTORY_SEPARATOR . 'vendor'
                                    . DIRECTORY_SEPARATOR . $package->config->name;
                     $finder->files()->name($file)->in($source_path);
 
                     foreach ($finder as $foundFile) {
-                        $this->moveFile($package, $autoloader, $foundFile);
+                        $filePath = $foundFile->getRealPath();
+                        $files_to_move[ $filePath ] = $foundFile;
                     }
                 }
 
@@ -141,9 +144,14 @@ class Mover
 
                     $finder->files()->in($source_path);
 
-                    foreach ($finder as $file) {
-                        $this->moveFile($package, $autoloader, $file);
+                    foreach ($finder as $foundFile) {
+                        $filePath = $foundFile->getRealPath();
+                        $files_to_move[ $filePath ] = $foundFile;
                     }
+                }
+
+                foreach ($files_to_move as $foundFile) {
+                    $this->moveFile($package, $autoloader, $foundFile);
                 }
             }
 

--- a/tests/MoverTest.php
+++ b/tests/MoverTest.php
@@ -2,8 +2,11 @@
 declare(strict_types=1);
 
 use CoenJacobs\Mozart\Composer\Package;
+use CoenJacobs\Mozart\Console\Commands\Compose;
 use CoenJacobs\Mozart\Mover;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class MoverTest extends TestCase
 {
@@ -140,6 +143,65 @@ class MoverTest extends TestCase
     }
 
     /**
+     * If a file is specified more than once in an autoloader, e.g. is explicitly listed and is also in a folder listed,
+     * a "File already exists at path" error occurs.
+     *
+     * To fix this, we enumerate the files to be copied using a dictionary indexed with the source file path, then loop
+     * and copy, thus only copying each one once.
+     *
+     * Original error:
+     * "League\Flysystem\FileExistsException : File already exists at path: lib/classes/tecnickcom/tcpdf/tcpdf.php"
+     *
+     * Test is using a known problematic autoloader:
+     * "iio/libmergepdf": {
+     *   "classmap": [
+     *     "config",
+     *     "include",
+     *     "tcpdf.php",
+     *     "tcpdf_parser.php",
+     *     "tcpdf_import.php",
+     *     "tcpdf_barcodes_1d.php",
+     *     "tcpdf_barcodes_2d.php",
+     *     "include/tcpdf_colors.php",
+     *     "include/tcpdf_filters.php",
+     *     "include/tcpdf_font_data.php",
+     *     "include/tcpdf_fonts.php",
+     *     "include/tcpdf_images.php",
+     *     "include/tcpdf_static.php",
+     *     "include/barcodes/datamatrix.php",
+     *     "include/barcodes/pdf417.php",
+     *     "include/barcodes/qrcode.php"
+     *    ]
+     *  }
+     *
+     * @see https://github.com/coenjacobs/mozart/issues/89
+     *
+     * @test
+     */
+    public function it_moves_each_file_once_per_namespace()
+    {
+
+        // The composer.json with the Mozart requirement and `mozart compose` removed.
+        copy(__DIR__ . '/issue89-composer.json', $this->testsWorkingDir . '/composer.json');
+
+        chdir($this->testsWorkingDir);
+
+        exec('composer install');
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $mozartCompose = new Compose();
+
+        // $this->expectException(League\Flysystem\FileExistsException::class);
+
+        $result = $mozartCompose->run($inputInterfaceMock, $outputInterfaceMock);
+
+        // On the failing test, an exception was thrown and this line was not reached.
+        $this->assertEquals(0, $result);
+    }
+
+    /**
      * Delete $this->testsWorkingDir after each test.
      *
      * @see https://stackoverflow.com/questions/3349753/delete-directory-with-files-in-it
@@ -147,7 +209,7 @@ class MoverTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-
+        
         $dir = $this->testsWorkingDir;
 
         $it = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS);
@@ -163,5 +225,6 @@ class MoverTest extends TestCase
             }
         }
         rmdir($dir);
+        chdir(__DIR__);
     }
 }

--- a/tests/issue89-composer.json
+++ b/tests/issue89-composer.json
@@ -1,0 +1,18 @@
+{
+  "require": {
+    "iio/libmergepdf": "^4.0"
+  },
+  "extra": {
+    "mozart": {
+      "dep_namespace": "MyLibMerge\\Vendor",
+      "dep_directory": "/lib/packages/",
+      "classmap_directory": "/lib/classes/",
+      "classmap_prefix": "MyLibMerge_",
+      "excluded_packages": [
+      ],
+      "override_autoload": {
+      },
+      "delete_vendor_directories": true
+    }
+  }
+}


### PR DESCRIPTION
Before moving files, builds a dictionary of files to be moved, using the source filie path as the dictionary key, so if the same file is in the autoloader more than once, it is only moved once.