### PR TITLE
Use cs2pr for PHPCS annotations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install PHP
-        uses: shivammathur/setup-php@1.3.7
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          tools: composer, cs2pr
       - name: Debugging
         run: |
           php --version
@@ -41,4 +42,4 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-suggest --no-progress
       - name: Run validate
-        run: composer run lint
+        run: vendor/bin/phpcs -q -n --report=checkstyle | cs2pr


### PR DESCRIPTION
I saw recently [WordPress added PHPCS annotations](https://make.wordpress.org/core/2020/10/15/introducing-github-actions-for-automated-testing/) so (as distinct from #72 ) I took a look at their approach and copied it here. Somewhere down the chain, [a PR of mine](https://github.com/staabm/annotate-pull-request-from-checkstyle/issues/48) is referenced!

The `workflow.yml` adds `tools: composer, cs2pr` which is [staabm/annotate-pull-request-from-checkstyle](https://github.com/staabm/annotate-pull-request-from-checkstyle) and then pipes another report type through that. This requires an upgrade of `setup-php`.
