### PR TITLE
Do not edit class declarations inside namespaces

### DIFF
--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -27,7 +27,7 @@ class ClassmapReplacer extends BaseReplacer
 						|										# if found, match that much before repeating the search 
 																# on the remainder of the string
 						(?:abstract\sclass|class|interface)\s+	# Look behind for class, abstract class, interface
-						([a-zA-Z0-9_\x7f-\xff]*)				# Match the word until the first 
+						([a-zA-Z0-9_\x7f-\xff]+)				# Match the word until the first 
 																# non-classname-valid character
 						\s?										# Allow a space after
 						(?:{|extends|implements|\n)				# Class declaration can be followed by {, extends, 

--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -1,10 +1,15 @@
 <?php
+/**
+ * The purpose of this file is to find and update classnames (and interfaces...) in their declarations.
+ * Those replaced are recorded and their uses elsewhere are updated in a later step.
+ */
 
 namespace CoenJacobs\Mozart\Replace;
 
 class ClassmapReplacer extends BaseReplacer
 {
-    /** @var array */
+
+    /** @var string[] */
     public $replacedClasses = [];
 
     /** @var string */
@@ -13,7 +18,14 @@ class ClassmapReplacer extends BaseReplacer
     public function replace($contents)
     {
         return preg_replace_callback(
-            '/(?:[abstract]*class |interface )([a-zA-Z0-9_\x7f-\xff]+)\s?(?:\n*|{| extends| implements)/',
+            "
+			/													# Start the pattern 
+						(?:abstract\sclass|class|interface)\s+	# Look behind for class, abstract class, interface
+						([a-zA-Z0-9_\x7f-\xff]+)				# Match the word made of valid classname characters
+						\s?										# Allow a space after
+						(?:{|extends|implements|\n)				# Class declaration can be followed by {, extends, implements, or a new line
+			/x", //  non-greedy matching by default, ignore whitespace in regex.
+
             function ($matches) {
                 $replace = $this->classmap_prefix . $matches[1];
                 $this->saveReplacedClass($matches[1], $replace);

--- a/tests/replacers/ClassMapReplacerTest.php
+++ b/tests/replacers/ClassMapReplacerTest.php
@@ -137,20 +137,12 @@ class ClassMapReplacerTest extends TestCase
     {
 
         $input = "
-		
 		namespace My_Project {
-		
-		class A_Class { }
-		
+			class A_Class { }
 		}
-		
-		
 		namespace {
-		
-		class B_Class { }
-		
+			class B_Class { }
 		}
-		
 		";
 
         $replacer = new ClassmapReplacer();

--- a/tests/replacers/ClassMapReplacerTest.php
+++ b/tests/replacers/ClassMapReplacerTest.php
@@ -91,51 +91,52 @@ class ClassMapReplacerTest extends TestCase
     }
 
 
-	/**
-	 * @see ClassmapReplacerIntegrationTest::test_it_does_not_make_classname_replacement_inside_namespaced_file()
-	 * @see https://github.com/coenjacobs/mozart/issues/93
-	 *
-	 * @test
-	 */
-	public function it_does_not_replace_inside_namespace_multiline(): void
-	{
-		$input = "
+    /**
+     * @see ClassmapReplacerIntegrationTest::test_it_does_not_make_classname_replacement_inside_namespaced_file()
+     * @see https://github.com/coenjacobs/mozart/issues/93
+     *
+     * @test
+     */
+    public function it_does_not_replace_inside_namespace_multiline(): void
+    {
+        $input = "
         namespace Mozart;
         class Hello_World
         ";
-		$replacer = new ClassmapReplacer();
-		$replacer->classmap_prefix = 'Mozart_';
-		$result = $replacer->replace($input);
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $result = $replacer->replace($input);
 
-		$this->assertEquals($input, $result);
-	}
+        $this->assertEquals($input, $result);
+    }
 
-	/**
-	 * @see ClassmapReplacerIntegrationTest::test_it_does_not_make_classname_replacement_inside_namespaced_file()
-	 * @see https://github.com/coenjacobs/mozart/issues/93
-	 *
-	 * @test
-	 */
-	public function it_does_not_replace_inside_namespace_singleline(): void
-	{
-		$input = "namespace Mozart; class Hello_World";
-		$replacer = new ClassmapReplacer();
-		$replacer->classmap_prefix = 'Mozart_';
-		$result = $replacer->replace($input);
+    /**
+     * @see ClassmapReplacerIntegrationTest::test_it_does_not_make_classname_replacement_inside_namespaced_file()
+     * @see https://github.com/coenjacobs/mozart/issues/93
+     *
+     * @test
+     */
+    public function it_does_not_replace_inside_namespace_singleline(): void
+    {
+        $input = "namespace Mozart; class Hello_World";
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $result = $replacer->replace($input);
 
-		$this->assertEquals($input, $result);
-	}
+        $this->assertEquals($input, $result);
+    }
 
-	/**
-	 * It's possible to have multiple namespaces inside one file.
-	 *
-	 * To have two classes in one file, one in a namespace and the other not, the global namespace needs to be explicit.
-	 *
-	 * @test
-	 */
-	public function it_does_not_replace_inside_named_namespace_but_does_inside_explicit_global_namespace(): void {
+    /**
+     * It's possible to have multiple namespaces inside one file.
+     *
+     * To have two classes in one file, one in a namespace and the other not, the global namespace needs to be explicit.
+     *
+     * @test
+     */
+    public function it_does_not_replace_inside_named_namespace_but_does_inside_explicit_global_namespace(): void
+    {
 
-		$input = "
+        $input = "
 		
 		namespace My_Project {
 		
@@ -152,10 +153,11 @@ class ClassMapReplacerTest extends TestCase
 		
 		";
 
-		$replacer = new ClassmapReplacer();
-		$replacer->classmap_prefix = 'Mozart_';
-		$result = $replacer->replace($input);
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $result = $replacer->replace($input);
 
-		$this->assertStringContainsString( 'Mozart_B_Class', $result );
-	}
+        $this->assertStringNotContainsString('Mozart_A_Class', $result);
+        $this->assertStringContainsString('Mozart_B_Class', $result);
+    }
 }

--- a/tests/replacers/ClassMapReplacerTest.php
+++ b/tests/replacers/ClassMapReplacerTest.php
@@ -89,4 +89,73 @@ class ClassMapReplacerTest extends TestCase
         $contents = $replacer->replace($contents);
         $this->assertEquals("class Mozart_Hello_World", $contents);
     }
+
+
+	/**
+	 * @see ClassmapReplacerIntegrationTest::test_it_does_not_make_classname_replacement_inside_namespaced_file()
+	 * @see https://github.com/coenjacobs/mozart/issues/93
+	 *
+	 * @test
+	 */
+	public function it_does_not_replace_inside_namespace_multiline(): void
+	{
+		$input = "
+        namespace Mozart;
+        class Hello_World
+        ";
+		$replacer = new ClassmapReplacer();
+		$replacer->classmap_prefix = 'Mozart_';
+		$result = $replacer->replace($input);
+
+		$this->assertEquals($input, $result);
+	}
+
+	/**
+	 * @see ClassmapReplacerIntegrationTest::test_it_does_not_make_classname_replacement_inside_namespaced_file()
+	 * @see https://github.com/coenjacobs/mozart/issues/93
+	 *
+	 * @test
+	 */
+	public function it_does_not_replace_inside_namespace_singleline(): void
+	{
+		$input = "namespace Mozart; class Hello_World";
+		$replacer = new ClassmapReplacer();
+		$replacer->classmap_prefix = 'Mozart_';
+		$result = $replacer->replace($input);
+
+		$this->assertEquals($input, $result);
+	}
+
+	/**
+	 * It's possible to have multiple namespaces inside one file.
+	 *
+	 * To have two classes in one file, one in a namespace and the other not, the global namespace needs to be explicit.
+	 *
+	 * @test
+	 */
+	public function it_does_not_replace_inside_named_namespace_but_does_inside_explicit_global_namespace(): void {
+
+		$input = "
+		
+		namespace My_Project {
+		
+		class A_Class { }
+		
+		}
+		
+		
+		namespace {
+		
+		class B_Class { }
+		
+		}
+		
+		";
+
+		$replacer = new ClassmapReplacer();
+		$replacer->classmap_prefix = 'Mozart_';
+		$result = $replacer->replace($input);
+
+		$this->assertStringContainsString( 'Mozart_B_Class', $result );
+	}
 }

--- a/tests/replacers/ClassmapReplacerIntegrationTest.php
+++ b/tests/replacers/ClassmapReplacerIntegrationTest.php
@@ -64,10 +64,6 @@ class ClassmapReplacerIntegrationTest extends TestCase
         $this->composer = $composer;
     }
 
-	/**
-	 * The unit test for issue #81 began failing when addressing #93,
-	 */
-
     /**
      * Issue #93 shows a classname being updated inside a class whose namespace has also been updated
      * by Mozart.

--- a/tests/replacers/ClassmapReplacerIntegrationTest.php
+++ b/tests/replacers/ClassmapReplacerIntegrationTest.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+
+use CoenJacobs\Mozart\Console\Commands\Compose;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @covers CoenJacobs\Mozart\Replace\ClassmapReplacer::
+ *
+ * Class NamespaceReplacerIntegrationTest
+ */
+class ClassmapReplacerIntegrationTest extends TestCase
+{
+
+    /**
+     * A temporary directory for creating and deleting files for these tests.
+     *
+     * @var string
+     */
+    protected $testsWorkingDir;
+
+    /**
+     * @var stdClass
+     */
+    protected $composer;
+
+    /**
+     * Set up a common settings object.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testsWorkingDir = __DIR__ . '/temptestdir';
+        if (!file_exists($this->testsWorkingDir)) {
+            mkdir($this->testsWorkingDir);
+        }
+
+        $mozart_config = new class() {
+            public $dep_namespace = "Mozart";
+            public $classmap_prefix = "Mozart_";
+            public $dep_directory = "/dep_directory/";
+            public $classmap_directory = "/classmap_directory/";
+
+        };
+
+        $composer = new class() {
+            public $repositories = array();
+            public $require = array();
+            public $minimum_stability = "dev";
+            public $extra;
+        };
+
+        $composer->extra = new class() {
+            public $mozart;
+        };
+
+        $composer->extra->mozart = $mozart_config;
+
+        $this->composer = $composer;
+    }
+
+	/**
+	 * The unit test for issue #81 began failing when addressing #93,
+	 */
+
+    /**
+     * Issue #93 shows a classname being updated inside a class whose namespace has also been updated
+     * by Mozart.
+     *
+     * This is caused by the same files being loaded by both a PSR-4 autolaoder and classmap autoloader.
+     * @see https://github.com/katzgrau/KLogger/blob/de2d3ab6777a393a9879e0496ebb8e0644066e3f/composer.json#L24-L29
+     */
+    public function test_it_does_not_make_classname_replacement_inside_namespaced_file()
+    {
+
+        $composer = $this->composer;
+
+        $composer->repositories[] = new class() {
+            public $url = "https://github.com/BrianHenryIE/bh-wp-logger";
+            public $type = "git";
+        };
+
+        $composer->require["brianhenryie/wp-logger"] = "dev-master#dd2bb0665e01e11b282178e76a2334198d3860c5";
+
+        $composer_json_string = json_encode($composer);
+	    $composer_json_string = str_replace('minimum_stability','minimum-stability', $composer_json_string);
+
+        file_put_contents($this->testsWorkingDir . '/composer.json', $composer_json_string);
+
+        chdir($this->testsWorkingDir);
+
+        exec('composer install');
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $mozartCompose = new Compose();
+
+        $result = $mozartCompose->run($inputInterfaceMock, $outputInterfaceMock);
+
+        $mpdf_php = file_get_contents($this->testsWorkingDir .'/dep_directory/BrianHenryIE/WP_Logger/class-logger.php');
+
+        // Confirm problem is gone.
+        $this->assertStringNotContainsString('class Mozart_Logger extends', $mpdf_php);
+
+        // Confirm solution is correct.
+        $this->assertStringContainsString('class Logger extends', $mpdf_php);
+    }
+
+
+    /**
+     * Delete $this->testsWorkingDir after each test.
+     *
+     * @see https://stackoverflow.com/questions/3349753/delete-directory-with-files-in-it
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $dir = $this->testsWorkingDir;
+
+        $it = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS);
+        $files = new RecursiveIteratorIterator(
+            $it,
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getRealPath());
+            } else {
+                unlink($file->getRealPath());
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/replacers/ClassmapReplacerIntegrationTest.php
+++ b/tests/replacers/ClassmapReplacerIntegrationTest.php
@@ -84,7 +84,7 @@ class ClassmapReplacerIntegrationTest extends TestCase
         $composer->require["brianhenryie/wp-logger"] = "dev-master#dd2bb0665e01e11b282178e76a2334198d3860c5";
 
         $composer_json_string = json_encode($composer);
-	    $composer_json_string = str_replace('minimum_stability','minimum-stability', $composer_json_string);
+        $composer_json_string = str_replace('minimum_stability', 'minimum-stability', $composer_json_string);
 
         file_put_contents($this->testsWorkingDir . '/composer.json', $composer_json_string);
 
@@ -99,13 +99,13 @@ class ClassmapReplacerIntegrationTest extends TestCase
 
         $result = $mozartCompose->run($inputInterfaceMock, $outputInterfaceMock);
 
-        $mpdf_php = file_get_contents($this->testsWorkingDir .'/dep_directory/BrianHenryIE/WP_Logger/class-logger.php');
+        $php_string = file_get_contents($this->testsWorkingDir .'/dep_directory/BrianHenryIE/WP_Logger/class-logger.php');
 
         // Confirm problem is gone.
-        $this->assertStringNotContainsString('class Mozart_Logger extends', $mpdf_php);
+        $this->assertStringNotContainsString('class Mozart_Logger extends', $php_string);
 
         // Confirm solution is correct.
-        $this->assertStringContainsString('class Logger extends', $mpdf_php);
+        $this->assertStringContainsString('class Logger extends', $php_string);
     }
 
 


### PR DESCRIPTION
Fix for #93 .

ClassmapReplacer specific.
Short-circuits the regex replacer when a named namespace is found.
Accommodates an explicit global namespace following a named namespace, in which case the classes _will_ be renamed.