### PR TITLE
Do NOT parse words in comments as class names

### DIFF
--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -20,28 +20,27 @@ class ClassmapReplacer extends BaseReplacer
 
         return preg_replace_callback(
             "
-			/													# Start the pattern
-						namespace\s+[a-zA-Z0-9_\x7f-\xff\\\\]+[;{\s\n]{1}.*?(?=namespace|$) 
-																# Look for a preceeding namespace declaration, up until 
-																# a potential second namespace declaration
-						|										# if found, match that much before continuing the search 
-																# on the remainder of the string
-						\s*\\/\\/\s*[^\n]* |					# Skip line comments
-						\s*\\*[^\n]*? |							# Skip multiline comment bodies
-						.*?\\*\\/ |								# Skip multiline comment endings			
-						\s*										# whitespace is allowed before 
-						(?:abstract\sclass|class|interface)\s+	# Look behind for class, abstract class, interface
-						([a-zA-Z0-9_\x7f-\xff]+)				# Match the word until the first 
-																# non-classname-valid character
-						\s?										# Allow a space after
-						(?:{|extends|implements|\n|$)				# Class declaration can be followed by {, extends, 
-																# implements, or a new line
-			/sx", //                                            # dot matches newline, ignore whitespace in regex.
+			/											# Start the pattern
+				namespace\s+[a-zA-Z0-9_\x7f-\xff\\\\]+[;{\s\n]{1}.*?(?=namespace|$) 
+														# Look for a preceeding namespace declaration, up until a 
+														# potential second namespace declaration.
+				|										# if found, match that much before continuing the search on
+														# the remainder of the string.
+				\s*\\/\\/\s*[^\n]* |					# Skip line comments
+				\s*\\*[^\n]*? |							# Skip multiline comment bodies
+				.*?\\*\\/ |								# Skip multiline comment endings			
+				\s*										# Whitespace is allowed before 
+				(?:abstract\sclass|class|interface)\s+	# Look behind for class, abstract class, interface
+				([a-zA-Z0-9_\x7f-\xff]+)				# Match the word until the first non-classname-valid character
+				\s?										# Allow a space after
+				(?:{|extends|implements|\n|$)			# Class declaration can be followed by {, extends, implements 
+														# or a new line
+			/sx", //                                    # dot matches newline, ignore whitespace in regex.
             function ($matches) use ($contents) {
 
                 // If we didn't capture a proper class/interface, return.
-                if( 1 === count( $matches ) ) {
-	                return $matches[0];
+                if (1 === count($matches)) {
+                    return $matches[0];
                 }
 
 

--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -24,8 +24,10 @@ class ClassmapReplacer extends BaseReplacer
 						namespace\s+[a-zA-Z0-9_\x7f-\xff\\\\]+[;{\s\n]{1}.*?(?=namespace|$) 
 																# Look for a preceeding namespace declaration, up until 
 																# a potential second namespace declaration
-						|										# if found, match that much before repeating the search 
+						|										# if found, match that much before continuing the search 
 																# on the remainder of the string
+						(?:^|\\\n|;)							# class declatartion must be on a new line or following a ;
+						\s*										# whitespace is allowed before 
 						(?:abstract\sclass|class|interface)\s+	# Look behind for class, abstract class, interface
 						([a-zA-Z0-9_\x7f-\xff]+)				# Match the word until the first 
 																# non-classname-valid character

--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -26,21 +26,24 @@ class ClassmapReplacer extends BaseReplacer
 																# a potential second namespace declaration
 						|										# if found, match that much before continuing the search 
 																# on the remainder of the string
-						(?:^|\\\n|;)							# class declatartion must be on a new line or following a ;
+						\s*\\/\\/\s*[^\n]* |					# Skip line comments
+						\s*\\*[^\n]*? |							# Skip multiline comment bodies
+						.*?\\*\\/ |								# Skip multiline comment endings			
 						\s*										# whitespace is allowed before 
 						(?:abstract\sclass|class|interface)\s+	# Look behind for class, abstract class, interface
 						([a-zA-Z0-9_\x7f-\xff]+)				# Match the word until the first 
 																# non-classname-valid character
 						\s?										# Allow a space after
-						(?:{|extends|implements|\n)				# Class declaration can be followed by {, extends, 
+						(?:{|extends|implements|\n|$)				# Class declaration can be followed by {, extends, 
 																# implements, or a new line
 			/sx", //                                            # dot matches newline, ignore whitespace in regex.
             function ($matches) use ($contents) {
 
-                // If we're inside a namespace other than the global namesspace, just return.
-                if (preg_match('/^namespace\s+[a-zA-Z0-9_\x7f-\xff\\\\]+[;{\s\n]{1}.*/', $matches[0])) {
-                    return $matches[0] ;
+                // If we didn't capture a proper class/interface, return.
+                if( 1 === count( $matches ) ) {
+	                return $matches[0];
                 }
+
 
                 // The prepended class name.
                 $replace = $this->classmap_prefix . $matches[1];

--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -27,23 +27,23 @@ class ClassmapReplacer extends BaseReplacer
         }
 
         return preg_replace_callback(
-            "
+            '
 			/											# Start the pattern
-				namespace\s+[a-zA-Z0-9_\x7f-\xff\\\\]+[;{\s\n]{1}.*?(?=namespace|$) 
+				namespace\s+[a-zA-Z0-9_\x7f-\xff\\\\]+[;{\s\n]{1}[\s\S]*?(?=namespace|$) 
 														# Look for a preceeding namespace declaration, up until a 
 														# potential second namespace declaration.
 				|										# if found, match that much before continuing the search on
 														# the remainder of the string.
-				\s*\\/\\/\s*[^\n]* |					# Skip line comments
-				\s*\\*[^\n]*? |							# Skip multiline comment bodies
-				.*?\\*\\/ |								# Skip multiline comment endings			
+				^\s*\/\/.*$ |							# Skip line comments
+				^\s*\*[^$\n]*? |						# Skip multiline comment bodies
+				^[^$\n]*?(?:\*\/) |						# Skip multiline comment endings			
 				\s*										# Whitespace is allowed before 
 				(?:abstract\sclass|class|interface)\s+	# Look behind for class, abstract class, interface
 				([a-zA-Z0-9_\x7f-\xff]+)				# Match the word until the first non-classname-valid character
 				\s?										# Allow a space after
 				(?:{|extends|implements|\n|$)			# Class declaration can be followed by {, extends, implements 
 														# or a new line
-			/sx", //                                    # dot matches newline, ignore whitespace in regex.
+			/x', //                                     # x: ignore whitespace in regex.
             function ($matches) use ($contents) {
 
                 // If we didn't capture a proper class/interface, return.

--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -36,7 +36,9 @@ class ClassmapReplacer extends BaseReplacer
 														# the remainder of the string.
 				^\s*\/\/.*$ |							# Skip line comments
 				^\s*\*[^$\n]*? |						# Skip multiline comment bodies
-				^[^$\n]*?(?:\*\/) |						# Skip multiline comment endings			
+				^[^$\n]*?(?:\*\/) |						# Skip multiline comment endings
+				[\s\S]*?(?='.$this->classmap_prefix.')	# Match an already prefixed classname
+				[a-zA-Z0-9_\x7f-\xff]+ |				# before continuing on the remainder of the string	
 				\s*										# Whitespace is allowed before 
 				(?:abstract\sclass|class|interface)\s+	# Look behind for class, abstract class, interface
 				([a-zA-Z0-9_\x7f-\xff]+)				# Match the word until the first non-classname-valid character
@@ -50,7 +52,6 @@ class ClassmapReplacer extends BaseReplacer
                 if (1 === count($matches)) {
                     return $matches[0];
                 }
-
 
                 // The prepended class name.
                 $replace = $this->classmap_prefix . $matches[1];

--- a/tests/replacers/ClassMapReplacerTest.php
+++ b/tests/replacers/ClassMapReplacerTest.php
@@ -274,4 +274,24 @@ class ClassMapReplacerTest extends TestCase
         $replacer->replace($input);
         $this->assertArrayHasKey('Pear', $replacer->replacedClasses);
     }
+
+    /**
+     * @test
+     */
+    public function it_parses_classes_followed_by_comment()
+    {
+
+        $input = <<<'EOD'
+	class WP_Dependency_Installer {
+		/**
+		 *
+		 */
+EOD;
+
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $replacer->replace($input);
+
+        $this->assertArrayHasKey('WP_Dependency_Installer', $replacer->replacedClasses);
+    }
 }

--- a/tests/replacers/ClassMapReplacerTest.php
+++ b/tests/replacers/ClassMapReplacerTest.php
@@ -174,4 +174,104 @@ class ClassMapReplacerTest extends TestCase
         $this->assertArrayHasKey('Whatever', $replacer->replacedClasses);
     }
 
+    /**
+     *
+     * @test
+     */
+    public function it_does_not_treat_multiline_comments_as_classes()
+    {
+        $input = "
+    	 /**
+    	  * A class as good as any; class as.
+    	  */
+    	class Whatever {
+    	}
+    	";
+
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $replacer->replace($input);
+        $this->assertArrayNotHasKey('as', $replacer->replacedClasses);
+        $this->assertArrayHasKey('Whatever', $replacer->replacedClasses);
+    }
+
+    /**
+     * This worked without adding the expected regex:
+     *
+     * // \s*\\/?\\*{2,}[^\n]* |                        # Skip multiline comment bodies
+     *
+     * @test
+     */
+    public function it_does_not_treat_multiline_comments_opening_line_as_classes()
+    {
+        $input = "
+    	 /** A class as good as any; class as.
+    	  *
+    	  */
+    	class Whatever {
+    	}
+    	";
+
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $replacer->replace($input);
+        $this->assertArrayNotHasKey('as', $replacer->replacedClasses);
+        $this->assertArrayHasKey('Whatever', $replacer->replacedClasses);
+    }
+
+
+    /**
+     *
+     * @test
+     */
+    public function it_does_not_treat_multiline_comments_on_one_line_as_classes()
+    {
+        $input = "
+    	 /** A class as good as any; class as. */ class Whatever_Trevor {
+    	}
+    	";
+
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $replacer->replace($input);
+        $this->assertArrayNotHasKey('as', $replacer->replacedClasses);
+        $this->assertArrayHasKey('Whatever_Trevor', $replacer->replacedClasses);
+    }
+
+    /**
+     * If someone were to put a semicolon in the comment it would mess with the previous fix.
+     *
+     * @test
+     */
+    public function it_does_not_treat_comments_with_semicolons_as_classes()
+    {
+        $input = "
+    	// A class as good as any; class as versatile as any.
+    	class Whatever_Ever {
+    	
+    	}
+    	";
+
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $replacer->replace($input);
+        $this->assertArrayNotHasKey('as', $replacer->replacedClasses);
+        $this->assertArrayHasKey('Whatever_Ever', $replacer->replacedClasses);
+    }
+
+    /**
+     * @test
+     */
+    public function it_parses_classes_after_semicolon()
+    {
+
+        $input = "
+	    myvar = 123; class Pear { };
+	    ";
+
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $replacer->replace($input);
+        $this->assertArrayHasKey('Pear', $replacer->replacedClasses);
+    }
 }

--- a/tests/replacers/ClassMapReplacerTest.php
+++ b/tests/replacers/ClassMapReplacerTest.php
@@ -152,4 +152,26 @@ class ClassMapReplacerTest extends TestCase
         $this->assertStringNotContainsString('Mozart_A_Class', $result);
         $this->assertStringContainsString('Mozart_B_Class', $result);
     }
+
+
+    /**
+     *
+     * @test
+     */
+    public function it_does_not_treat_comments_as_classes()
+    {
+        $input = "
+    	// A class as good as any.
+    	class Whatever {
+    	
+    	}
+    	";
+
+        $replacer = new ClassmapReplacer();
+        $replacer->classmap_prefix = 'Mozart_';
+        $replacer->replace($input);
+        $this->assertArrayNotHasKey('as', $replacer->replacedClasses);
+        $this->assertArrayHasKey('Whatever', $replacer->replacedClasses);
+    }
+
 }


### PR DESCRIPTION
Fixes #86.

Requires #101.

Mostly tests.