### PR TITLE
Directory separator and its duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ vendor/
 .DS_Store
 composer.lock
 .phpunit.result.cache
+
+temptestdir

--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -2,6 +2,8 @@
 
 namespace CoenJacobs\Mozart\Composer\Autoload;
 
+use stdClass;
+
 abstract class NamespaceAutoloader implements Autoloader
 {
     /** @var string */
@@ -17,9 +19,9 @@ abstract class NamespaceAutoloader implements Autoloader
     public $paths = [];
 
     /**
-     * A package's composer.json config autoload key's value, where $key is `psr-1`|`psr-4`|`classmap`.
+     * A package's composer.json config autoload key's value, where $key is `psr-0`|`psr-4`|`classmap`.
      *
-     * @param $autoloadConfig
+     * @param stdClass[] $autoloadConfig
      */
     public function processConfig($autoloadConfig)
     {

--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -21,7 +21,7 @@ abstract class NamespaceAutoloader implements Autoloader
     /**
      * A package's composer.json config autoload key's value, where $key is `psr-0`|`psr-4`|`classmap`.
      *
-     * @param stdClass[] $autoloadConfig
+     * @param $autoloadConfig
      *
      * @return void
      */

--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -36,8 +36,5 @@ abstract class NamespaceAutoloader implements Autoloader
         return $this->namespace;
     }
 
-    public function getNamespacePath()
-    {
-        return '';
-    }
+    abstract public function getNamespacePath(): string;
 }

--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -22,7 +22,6 @@ abstract class NamespaceAutoloader implements Autoloader
      * A package's composer.json config autoload key's value, where $key is `psr-0`|`psr-4`|`classmap`.
      *
      * @param stdClass[] $autoloadConfig
-     * @param $autoloadConfig
      *
      * @return void
      */

--- a/src/Composer/Autoload/Psr0.php
+++ b/src/Composer/Autoload/Psr0.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @see https://www.php-fig.org/psr/psr-0/
+ */
 
 namespace CoenJacobs\Mozart\Composer\Autoload;
 

--- a/src/Composer/Autoload/Psr0.php
+++ b/src/Composer/Autoload/Psr0.php
@@ -7,4 +7,9 @@ namespace CoenJacobs\Mozart\Composer\Autoload;
 
 class Psr0 extends NamespaceAutoloader
 {
+
+    public function getNamespacePath(): string
+    {
+        return '';
+    }
 }

--- a/src/Composer/Autoload/Psr4.php
+++ b/src/Composer/Autoload/Psr4.php
@@ -1,15 +1,18 @@
 <?php
+/**
+ * @see https://www.php-fig.org/psr/psr-4/
+ */
 
 namespace CoenJacobs\Mozart\Composer\Autoload;
 
 class Psr4 extends NamespaceAutoloader
 {
-    public function getSearchNamespace()
+    public function getSearchNamespace(): string
     {
         return trim($this->namespace, '\\');
     }
 
-    public function getNamespacePath()
+    public function getNamespacePath(): string
     {
         return str_replace('\\', DIRECTORY_SEPARATOR, $this->namespace);
     }

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -177,26 +177,25 @@ class Mover
         // The relative path to the file from the project root.
         $sourceFilePath = $this->clean(str_replace($this->workingDir, '', $file->getPathname()));
 
-        $namespacePath = $this->clean($package->config->name);
+        $packageName = $this->clean($package->config->name);
 
         if ($autoloader instanceof NamespaceAutoloader) {
             $namespacePath = $this->clean($autoloader->getNamespacePath());
 
             // TODO: Should $path come from the NameSpaceAutoloader object?
-            $packageVendorPath = 'vendor' . DIRECTORY_SEPARATOR . $namespacePath
-                                 . DIRECTORY_SEPARATOR . $this->clean($path);
+	        $sourceVendorPath = $this->clean('vendor' . DIRECTORY_SEPARATOR . $packageName
+                                 . DIRECTORY_SEPARATOR . $path);
 
-            $mozartDepPath = $this->dep_directory . DIRECTORY_SEPARATOR . $namespacePath;
+	        $destinationMozartPath = $this->dep_directory . DIRECTORY_SEPARATOR . $namespacePath;
 
-            $targetFilePath = str_ireplace($packageVendorPath, $mozartDepPath, $sourceFilePath);
+            $targetFilePath = str_ireplace($sourceVendorPath, $destinationMozartPath, $sourceFilePath);
         } else {
-            $classmapDirectory = $this->classmap_directory;
 
-            $packageVendorPath = 'vendor' . DIRECTORY_SEPARATOR . $namespacePath;
+            $sourceVendorPath = 'vendor' . DIRECTORY_SEPARATOR . $packageName;
 
-            $mozartClassesPath = $classmapDirectory . DIRECTORY_SEPARATOR . $namespacePath;
+            $destinationMozartPath = $this->classmap_directory . DIRECTORY_SEPARATOR . $packageName;
 
-            $targetFilePath = str_ireplace($packageVendorPath, $mozartClassesPath, $sourceFilePath);
+            $targetFilePath = str_ireplace($sourceVendorPath, $destinationMozartPath, $sourceFilePath);
         }
 
         $this->filesystem->copy($sourceFilePath, $targetFilePath);

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -10,6 +10,7 @@ use CoenJacobs\Mozart\Composer\Autoload\Psr4;
 use CoenJacobs\Mozart\Composer\Package;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
+use stdClass;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -25,6 +26,12 @@ class Mover
     /** @var string */
     protected $dep_directory;
 
+    /** @var string */
+    protected $classmap_directory;
+
+    /** @var stdClass */
+    protected $config;
+
     /** @var Filesystem */
     protected $filesystem;
 
@@ -33,6 +40,7 @@ class Mover
 
     public function __construct($workingDir, $config)
     {
+        $this->config = $config;
         
         $this->workingDir = DIRECTORY_SEPARATOR . $this->clean($workingDir);
 
@@ -73,7 +81,8 @@ class Mover
             switch ($autoloaderType) {
                 case Psr0::class:
                 case Psr4::class:
-                    $outputDir = $this->dep_directory . DIRECTORY_SEPARATOR . $this->clean($packageAutoloader->namespace);
+                    $outputDir = $this->dep_directory . DIRECTORY_SEPARATOR .
+                                 $this->clean($packageAutoloader->namespace);
                     $this->filesystem->deleteDir($outputDir);
                     break;
                 case Classmap::class:

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -15,7 +15,11 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class Mover
 {
-    /** @var string */
+    /**
+     * The only path variable with a leading slash.
+     *
+     * @var string
+     */
     protected $workingDir;
 
     /** @var string */

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -198,14 +198,13 @@ class Mover
             $namespacePath = $this->clean($autoloader->getNamespacePath());
 
             // TODO: Should $path come from the NameSpaceAutoloader object?
-	        $sourceVendorPath = $this->clean('vendor' . DIRECTORY_SEPARATOR . $packageName
+            $sourceVendorPath = $this->clean('vendor' . DIRECTORY_SEPARATOR . $packageName
                                  . DIRECTORY_SEPARATOR . $path);
 
-	        $destinationMozartPath = $this->dep_directory . DIRECTORY_SEPARATOR . $namespacePath;
+            $destinationMozartPath = $this->dep_directory . DIRECTORY_SEPARATOR . $namespacePath;
 
             $targetFilePath = str_ireplace($sourceVendorPath, $destinationMozartPath, $sourceFilePath);
         } else {
-
             $sourceVendorPath = 'vendor' . DIRECTORY_SEPARATOR . $packageName;
 
             $destinationMozartPath = $this->classmap_directory . DIRECTORY_SEPARATOR . $packageName;

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -41,8 +41,8 @@ class Mover
     public function __construct($workingDir, $config)
     {
         $this->config = $config;
-        
-        $this->workingDir = DIRECTORY_SEPARATOR . $this->clean($workingDir);
+
+        $this->workingDir = $workingDir;
 
         $this->dep_directory = $this->clean($config->dep_directory);
         $this->classmap_directory = $this->clean($config->classmap_directory);

--- a/tests/MoverIntegrationTest.php
+++ b/tests/MoverIntegrationTest.php
@@ -121,7 +121,7 @@ class MoverIntegrationTest extends TestCase
 
         $composer = $this->composer;
 
-        $composer->require["iio/libmergepdf"] = "4.0.3";
+        $composer->require["iio/libmergepdf"] = "4.0.4";
 
         file_put_contents($this->testsWorkingDir . '/composer.json', json_encode($composer));
 

--- a/tests/MoverIntegrationTest.php
+++ b/tests/MoverIntegrationTest.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+
+use CoenJacobs\Mozart\Console\Commands\Compose;
+use League\Flysystem\FileExistsException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @covers CoenJacobs\Mozart\Mover::
+ *
+
+ */
+class MoverIntegrationTest extends TestCase
+{
+
+    /**
+     * A temporary directory for creating and deleting files for these tests.
+     *
+     * @var string
+     */
+    protected $testsWorkingDir;
+
+    /**
+     * @var stdClass
+     */
+    protected $composer;
+
+    /**
+     * Set up a common settings object.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testsWorkingDir = __DIR__ . '/temptestdir';
+        if (file_exists($this->testsWorkingDir)) {
+            $this->delete_dir($this->testsWorkingDir);
+        }
+        mkdir($this->testsWorkingDir);
+
+        $mozart_config = new class() {
+            public $dep_namespace = "Mozart";
+            public $classmap_prefix = "Mozart_";
+            public $dep_directory = "/dep_directory/";
+            public $classmap_directory = "/classmap_directory/";
+
+        };
+
+        $composer = new class() {
+            public $require = array();
+            public $extra;
+        };
+
+        $composer->extra = new class() {
+            public $mozart;
+        };
+
+        $composer->extra->mozart = $mozart_config;
+
+        $this->composer = $composer;
+    }
+
+    /**
+     * Issue 43. Needs "aws/aws-sdk-php".
+     *
+     * League\Flysystem\FileExistsException : File already exists at path:
+     * dep_directory/vendor/guzzle/guzzle/src/Guzzle/Cache/Zf1CacheAdapter.php
+     */
+    public function test_aws_sdk_succeeds()
+    {
+
+        $composer = $this->composer;
+
+        $composer->require["aws/aws-sdk-php"] = "2.8.31";
+
+        file_put_contents($this->testsWorkingDir . '/composer.json', json_encode($composer));
+
+        chdir($this->testsWorkingDir);
+
+        exec('composer install');
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $mozartCompose = new Compose();
+
+        $result = $mozartCompose->run($inputInterfaceMock, $outputInterfaceMock);
+
+        try {
+            $php_string = file_get_contents($this->testsWorkingDir . '/dep_directory/Aws/Ses/Common/Aws.php');
+        } catch (FileExistsException $e) {
+            $this->fail();
+        }
+
+//        $this->assertStringContainsString('class Mpdf implements', $php_string);
+    }
+
+
+    /**
+     * Issue 90. Needs "iio/libmergepdf".
+     *
+     * Error: "File already exists at path: classmap_directory/tecnickcom/tcpdf/tcpdf.php".
+     */
+    public function test_libpdfmerge_succeeds()
+    {
+
+        $composer = $this->composer;
+
+        $composer->require["iio/libmergepdf"] = "4.0.3";
+
+        file_put_contents($this->testsWorkingDir . '/composer.json', json_encode($composer));
+
+        chdir($this->testsWorkingDir);
+
+        exec('composer install');
+
+        $inputInterfaceMock = $this->createMock(InputInterface::class);
+        $outputInterfaceMock = $this->createMock(OutputInterface::class);
+
+        $mozartCompose = new Compose();
+
+        $result = $mozartCompose->run($inputInterfaceMock, $outputInterfaceMock);
+	    // classmap_directory/tecnickcom/tcpdf/tcpdf.php
+        $php_string = file_get_contents($this->testsWorkingDir .'/dep_directory/iio/libmergepdf/tcpdi/tcpdi.php');
+
+//        // Confirm solution is correct.
+//        $this->assertStringContainsString('class Mpdf implements', $php_string);
+    }
+
+
+    /**
+     * Delete $this->testsWorkingDir after each test.
+     *
+     * @see https://stackoverflow.com/questions/3349753/delete-directory-with-files-in-it
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $dir = $this->testsWorkingDir;
+
+        $this->delete_dir($dir);
+    }
+
+    protected function delete_dir($dir)
+    {
+		if(!file_exists($dir)){
+			return;
+		}
+
+
+        $it = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS);
+        $files = new RecursiveIteratorIterator(
+            $it,
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getRealPath());
+            } else {
+                unlink($file->getRealPath());
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
Fix for #90 , #43.

The meat in this is `trim(preg_replace('/[\/\\\\]+/', DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR)` which is run on every variable in `Mover::moveFile()` that is to be used in a file path. The provides Windows <-> Unix compatibility and by always trimming the slashes, makes it easier to reason inside the code. `$workingDir` is the only variable with a leading slash, since it is the absolute path and all others are relative.

~~No tests written, but existing tests are fine.~~ Marking it as draft for a few weeks while I test it in production!

Two integration tests added.
