### PR TITLE
Create phar and attach to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Build and attach Mozart.phar to each release
+
+on: release
+
+jobs:
+  create-phar:
+    runs-on: ubuntu-latest
+    name: Create Mozart phar
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@1.3.7
+        with:
+          php-version: 7.2
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-suggest --no-progress
+
+      - name: Create .phar
+        run: |
+          vendor/bin/phar-composer build .
+          php mozart.phar --version
+
+      - uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: mozart.phar
+          gzip: false
+          allow_override: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This package requires PHP 7.2 or higher in order to run the tool. You can use th
 **Warning:** This package is very experimental and breaking changes are very likely until version 1.0.0 is tagged. Use with caution, always wear a helmet when using this in production environments.
 
 ## Installation
+
+### Composer
+
 Install through Composer, only required in development environments:
 
 `composer require coenjacobs/mozart --dev`
@@ -13,6 +16,15 @@ Install through Composer, only required in development environments:
 This gives you a bin file named `mozart` inside your `vendor/bin` directory, after loading the whole package inside your project. Try running `vendor/bin/mozart` to verify it works.
 
 After configuring Mozart properly, the `mozart compose` command does all the magic.
+
+### Standalone Phar
+
+`mozart.phar` can be [downloaded from the releases](https://github.com/coenjacobs/mozart/releases):
+
+```
+composer install --no-dev
+php mozart.phar compose
+```
 
 ## Configuration
 Mozart requires little configuration. All you need to do is tell it where the bundled dependencies are going to be stored and what namespace they should be put inside. This configuration needs to be done in the `extra` property of your `composer.json` file:

--- a/bin/mozart
+++ b/bin/mozart
@@ -1,23 +1,27 @@
 #!/usr/bin/env php
 <?php
 call_user_func(function ($version) {
-    if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
-        require $autoload;
-    } elseif (is_file($autoload = getcwd() . '/../../autoload.php')) {
-        require $autoload;
-    }
+	if( ! Phar::running() ) {
+        if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
+            require $autoload;
+        } elseif (is_file($autoload = getcwd() . '/../../autoload.php')) {
+            require $autoload;
+        }
 
-    if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
-        require($autoload);
-    } elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
-        require($autoload);
-    } else {
-        fwrite(STDERR,
-            'You must set up the project dependencies, run the following commands:' . PHP_EOL .
-            'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
-            'php composer.phar install' . PHP_EOL
-        );
-        exit(1);
+		if ( is_file( $autoload = __DIR__ . '/../vendor/autoload.php' ) ) {
+			require( $autoload );
+		} elseif ( is_file( $autoload = __DIR__ . '/../../../autoload.php' ) ) {
+			require( $autoload );
+		} else {
+			fwrite( STDERR,
+				'You must set up the project dependencies, run the following commands:' . PHP_EOL .
+				'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+				'php composer.phar install' . PHP_EOL
+			);
+			exit( 1 );
+		}
+	} else {
+	    include 'phar://mozart.phar/vendor/autoload.php';
     }
 
     $app = new CoenJacobs\Mozart\Console\Application($version);

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         }
     },
     "require-dev": {
+        "clue/phar-composer": "^1.2",
         "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.5",
         "mheap/phpunit-github-actions-printer": "^1.4"


### PR DESCRIPTION
Uses [clue/phar-composer](clue/phar-composer) to create a standalone `mozart.phar` which can be used without being part of `require-dev`

Uses [meeDamian/github-release](https://github.com/marketplace/actions/github-release-create-update-and-upload-assets) to generate and attach the phar on every Mozart GitHub release.

To try it out:

```
curl -OL https://github.com/BrianHenryIE/mozart/releases/download/v0.6.0-bh/mozart.phar
php mozart.phar --version
composer install --no-dev
php mozart.phar compose
```

Should help with #79 #95 #96 
