### PR TITLE
Drop PHP 7.2 compat and introduce testing PHP 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php }} tests
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: Lint and test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mozart [![Latest Stable Version](https://poser.pugx.org/coenjacobs/mozart/v/stable.svg)](https://packagist.org/packages/coenjacobs/mozart) [![License](https://poser.pugx.org/coenjacobs/mozart/license.svg)](https://packagist.org/packages/coenjacobs/mozart)
 Composes all dependencies as a package inside a WordPress plugin. Load packages through Composer and have them wrapped inside your own namespace. Gone are the days when plugins could load conflicting versions of the same package, resulting in hard to reproduce bugs.
 
-This package requires PHP 7.2 or higher in order to run the tool. You can use the resulting files as a bundle, requiring any PHP version you like, even PHP 5.2.
+This package requires PHP 7.3 or higher in order to run the tool. You can use the resulting files as a bundle, requiring any PHP version you like, even PHP 5.2.
 
 **Warning:** This package is very experimental and breaking changes are very likely until version 1.0.0 is tagged. Use with caution, always wear a helmet when using this in production environments.
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "prefer-stable": true,
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.3|^8.0",
         "symfony/console": "^4|^5",
         "symfony/finder": "^4|^5",
         "league/flysystem": "^1.0"

--- a/tests/replacers/NamespaceReplacerIntegrationTest.php
+++ b/tests/replacers/NamespaceReplacerIntegrationTest.php
@@ -78,7 +78,7 @@ class NamespaceReplacerIntegrationTest extends TestCase
 
         $composer = $this->composer;
 
-        $composer->require["mpdf/mpdf"] = "8.0.8";
+        $composer->require["mpdf/mpdf"] = "8.0.10";
 
         file_put_contents($this->testsWorkingDir . '/composer.json', json_encode($composer));
 


### PR DESCRIPTION
Since [PHP 7.2 is unsupported](https://www.php.net/eol.php) now and PHP 8.0 is available, I'd like to change the supported PHP versions from 7.2, 7.3 and 7.4 to 7.3, 7.4 and 8.0. From here on, I'd like to support all PHP versions that still receive security support ("[Currently Supported Versions](https://www.php.net/supported-versions)") and basically roll with the PHP schedule.