### PR TITLE
Fix release script for building PHAR without development dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,11 @@ jobs:
 
       - name: Create .phar
         run: |
-          vendor/bin/phar-composer build .
-          php mozart.phar --version
+          wget -O phar-composer.phar https://github.com/clue/phar-composer/releases/download/v1.2.0/phar-composer-1.2.0.phar
+          php phar-composer.phar build .
+
+      - name: Test run mozart
+        run: php mozart.phar --version
 
       - uses: meeDamian/github-release@2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,12 @@ jobs:
       - name: Create .phar
         run: |
           wget -O phar-composer.phar https://github.com/clue/phar-composer/releases/download/v1.2.0/phar-composer-1.2.0.phar
-          php phar-composer.phar build .
+          mkdir build
+          mv vendor build/vendor
+          mv src build/src
+          mv bin build/bin
+          mv composer.json build
+          php -d phar.readonly=off phar-composer.phar build ./build/
 
       - name: Test run mozart
         run: php mozart.phar --version

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         }
     },
     "require-dev": {
-        "clue/phar-composer": "^1.2",
         "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.5",
         "mheap/phpunit-github-actions-printer": "^1.4",


### PR DESCRIPTION
Thank you @szepeviktor for #119, that definitely put me on the right track. Had some issues with the PHAR builder (requiring `phar.readonly=off` for it to write) and moved on from there. Your original idea was solid though, to use the PHAR, so I picked that commit - hope you don't mind. I personally like the temporary `/build` directory a bit better than putting the PHAR in `/tmp` because with `/build` I can specify what files I want in the resulting PHAR file.