### PR TITLE
Use positive lookahead to allow phrases - fix #124

### DIFF
--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -31,7 +31,7 @@ class NamespaceReplacer extends BaseReplacer
                   (?<![a-zA-Z0-9_]\\\\)      # Not a class-allowed character followed by a slash
                   (?<!class\s)				 # Not a class declaration
                   $searchNamespace			 # The namespace were looking for
-                  (?=;|\\\|\\|\sas)			 # Followed by one of
+                  (?=;|\\\|\||\sas)			 # Followed by one of
                   							 # semicolon when it is the class namespace itself
                   				             # backslash when it is part of a longer namespace or namespaced class
                   							 # pipe

--- a/src/Replace/NamespaceReplacer.php
+++ b/src/Replace/NamespaceReplacer.php
@@ -29,11 +29,15 @@ class NamespaceReplacer extends BaseReplacer
                 (                            # Start the namespace matcher
                   (?<!$dependencyNamespace)  # Does NOT start with the prefix
                   (?<![a-zA-Z0-9_]\\\\)      # Not a class-allowed character followed by a slash
-                  (?<!class\s)				 # Not a class declaration.
-                  $searchNamespace           # The namespace we're looking for
-                  [\\\|;\s]                  # Backslash, pipe, semicolon, or space
+                  (?<!class\s)				 # Not a class declaration
+                  $searchNamespace			 # The namespace were looking for
+                  (?=;|\\\|\\|\sas)			 # Followed by one of
+                  							 # semicolon when it is the class namespace itself
+                  				             # backslash when it is part of a longer namespace or namespaced class
+                  							 # pipe
+                  							 # space followed by the as keyword
                 )                            # End the namespace matcher
-            /Ux",
+            /Ux", # U non-greedy matching by default, x ignore whitespace in regex.
             function ($matches) {
                 return $matches[1] . $this->dep_namespace . $matches[2];
             },

--- a/tests/replacers/NamespaceReplacerTest.php
+++ b/tests/replacers/NamespaceReplacerTest.php
@@ -123,4 +123,20 @@ class NamespaceReplacerTest extends TestCase
 
         $this->assertEquals($expected, $replacer->replace($contents));
     }
+
+/**
+ * @test
+ */
+public function it_doesnt_prefix_function_types_that_happen_to_match_the_namespace() {
+
+    $namespace = 'Mpdf';
+    $prefix = "Mozart\\";
+
+    $replacer = self::createReplacer($namespace, $prefix);
+
+    $contents = 'public function getServices( Mpdf $mpdf, LoggerInterface $logger, $config, )';
+    $expected = 'public function getServices( Mpdf $mpdf, LoggerInterface $logger, $config, )';
+
+    $this->assertEquals($expected, $replacer->replace($contents));
+}
 }


### PR DESCRIPTION
Instead of looking for characters: '\', '|', ';', and ' ' (space), it now looks for phrases ";", "\", "|" and " as"

Fix for #124