### PR TITLE
Respect Composer vendor directory config option

### DIFF
--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -65,7 +65,7 @@ class Compose extends Command
         if (isset($composer->config) && isset($composer->config->{'vendor-dir'})) {
             $vendorDir = $composer->config->{'vendor-dir'};
         }
-        $config->vendor_dir = $vendorDir        
+        $config->vendor_dir = $vendorDir;
 
         $this->config = $config;
 

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -60,6 +60,12 @@ class Compose extends Command
         $config = $composer->extra->mozart;
 
         $config->dep_namespace = preg_replace("/\\\{2,}$/", "\\", "$config->dep_namespace\\");
+        
+        $vendorDir = 'vendor';
+        if (isset($composer->config) && isset($composer->config->{'vendor-dir'})) {
+            $vendorDir = $composer->config->{'vendor-dir'};
+        }
+        $config->vendor_dir = $vendorDir        
 
         $this->config = $config;
 
@@ -166,13 +172,9 @@ class Compose extends Command
     private function findPackages(array $slugs): array
     {
         $packages = [];
-        $vendorDir = 'vendor';
-        if (isset($this->config->config) && isset($this->config->config->vendor-dir)) {
-            $vendorDir = $this->config->config->{'vendor-dir'};
-        }
 
         foreach ($slugs as $package_slug) {
-            $packageDir = $this->workingDir . DIRECTORY_SEPARATOR . $vendorDir
+            $packageDir = $this->workingDir . DIRECTORY_SEPARATOR . $this->config->vendor_dir
                           . DIRECTORY_SEPARATOR . $package_slug . DIRECTORY_SEPARATOR;
 
             if (! is_dir($packageDir)) {

--- a/src/Console/Commands/Compose.php
+++ b/src/Console/Commands/Compose.php
@@ -166,9 +166,13 @@ class Compose extends Command
     private function findPackages(array $slugs): array
     {
         $packages = [];
+        $vendorDir = 'vendor';
+        if (isset($this->config->config) && isset($this->config->config->vendor-dir)) {
+            $vendorDir = $this->config->config->{'vendor-dir'};
+        }
 
         foreach ($slugs as $package_slug) {
-            $packageDir = $this->workingDir . DIRECTORY_SEPARATOR . 'vendor'
+            $packageDir = $this->workingDir . DIRECTORY_SEPARATOR . $vendorDir
                           . DIRECTORY_SEPARATOR . $package_slug . DIRECTORY_SEPARATOR;
 
             if (! is_dir($packageDir)) {

--- a/src/Mover.php
+++ b/src/Mover.php
@@ -116,7 +116,7 @@ class Mover
                 $finder = new Finder();
 
                 foreach ($autoloader->paths as $path) {
-                    $source_path = $this->workingDir . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR
+                    $source_path = $this->workingDir . DIRECTORY_SEPARATOR . $this->config->vendor_dir . DIRECTORY_SEPARATOR
                                    . $package->config->name . DIRECTORY_SEPARATOR . $path;
 
                     $source_path = str_replace('/', DIRECTORY_SEPARATOR, $source_path);
@@ -133,7 +133,7 @@ class Mover
                 $files_to_move = array();
 
                 foreach ($autoloader->files as $file) {
-                    $source_path = $this->workingDir . DIRECTORY_SEPARATOR . 'vendor'
+                    $source_path = $this->workingDir . DIRECTORY_SEPARATOR . $this->config->vendor_dir
                                    . DIRECTORY_SEPARATOR . $package->config->name;
                     $finder->files()->name($file)->in($source_path);
 
@@ -146,7 +146,7 @@ class Mover
                 $finder = new Finder();
 
                 foreach ($autoloader->paths as $path) {
-                    $source_path = $this->workingDir . DIRECTORY_SEPARATOR . 'vendor'
+                    $source_path = $this->workingDir . DIRECTORY_SEPARATOR . $this->config->vendor_dir
                                    . DIRECTORY_SEPARATOR . $package->config->name . DIRECTORY_SEPARATOR . $path;
 
                     $finder->files()->in($source_path);
@@ -186,7 +186,7 @@ class Mover
             $replaceWith = $this->config->dep_directory . $namespacePath;
             $targetFile = str_replace($this->workingDir, $replaceWith, $file->getPathname());
 
-            $packageVendorPath = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . $package->config->name
+            $packageVendorPath = DIRECTORY_SEPARATOR . $this->config->vendor_dir . DIRECTORY_SEPARATOR . $package->config->name
                                  . DIRECTORY_SEPARATOR . $path;
             $packageVendorPath = str_replace('/', DIRECTORY_SEPARATOR, $packageVendorPath);
             $targetFile = str_replace($packageVendorPath, '', $targetFile);
@@ -195,7 +195,7 @@ class Mover
             $replaceWith = $this->config->classmap_directory . DIRECTORY_SEPARATOR . $namespacePath;
             $targetFile = str_replace($this->workingDir, $replaceWith, $file->getPathname());
 
-            $packageVendorPath = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . $package->config->name
+            $packageVendorPath = DIRECTORY_SEPARATOR . $this->config->vendor_dir . DIRECTORY_SEPARATOR . $package->config->name
                                  . DIRECTORY_SEPARATOR;
             $packageVendorPath = str_replace('/', DIRECTORY_SEPARATOR, $packageVendorPath);
             $targetFile = str_replace($packageVendorPath, DIRECTORY_SEPARATOR, $targetFile);
@@ -219,7 +219,7 @@ class Mover
     protected function deletePackageVendorDirectories(): void
     {
         foreach ($this->movedPackages as $movedPackage) {
-            $packageDir = 'vendor' . DIRECTORY_SEPARATOR . $movedPackage;
+            $packageDir = $this->config->vendor_dir . DIRECTORY_SEPARATOR . $movedPackage;
             if (!is_dir($packageDir) || is_link($packageDir)) {
                 continue;
             }


### PR DESCRIPTION
Adds support for non-default vendor directory
Useful when working on a legacy wordpress theme or plugin where 'vendor' is already in use before adopting composer

https://getcomposer.org/doc/06-config.md#vendor-dir