### PR TITLE
Update `exclude_packages` references to expected `excluded_packages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Mozart requires little configuration. All you need to do is tell it where the bu
         "packages": [
             "pimple/pimple"
         ],
-        "exclude_packages": [
+        "excluded_packages": [
             "psr/container"
         ],
         "override_autoload": {
@@ -110,7 +110,7 @@ The following configuration is optional:
 
 - `delete_vendor_directories` is a boolean flag to indicate if the packages' vendor directories should be deleted after being processed. _default: true_.
 - `packages` is an optional array that defines the packages to be processed by Mozart. The array requires the slugs of packages in the same format as provided in your `composer.json`. Mozart will automatically rewrite dependencies of these packages as well. You don't need to add dependencies of these packages to the list. If this field is absent, all packages listed under composer require will be included.
-- `exclude_packages` is an optional array that defines the packages to be excluded from the processing performed by Mozart. This is useful if some of the packages in the `packages` array define dependent packages whose namespaces you want to keep unchanged. The array requires the slugs of the packages, as in the case of the `packages` array.
+- `excluded_packages` is an optional array that defines the packages to be excluded from the processing performed by Mozart. This is useful if some of the packages in the `packages` array define dependent packages whose namespaces you want to keep unchanged. The array requires the slugs of the packages, as in the case of the `packages` array.
 - `override_autoload` a dictionary, keyed with the package names, of autoload settings to replace those in the original packages' `composer.json` `autoload` property.
 
 After Composer has loaded the packages as defined in your `composer.json` file, you can now run `mozart compose` and Mozart will bundle your packages according to the above configuration. It is recommended to dump the autoloader after Mozart has finished running, in case there are new classes or namespaces generated that aren't included in the autoloader yet. 


### PR DESCRIPTION
This one caught me when following the installation instructions, which are otherwise very simple.

`excluded_packages` is expected (the extra `d`):

https://github.com/coenjacobs/mozart/blob/3b1243ca8505fa6436569800dc34269178930f39/src/Console/Commands/Compose.php#L74
https://github.com/coenjacobs/mozart/blob/3b1243ca8505fa6436569800dc34269178930f39/tests/issue89-composer.json#L11