### PR TITLE
allow to skip duplicated files

### DIFF
--- a/src/Mover.php
+++ b/src/Mover.php
@@ -201,6 +201,10 @@ class Mover
             $targetFile = str_replace($packageVendorPath, DIRECTORY_SEPARATOR, $targetFile);
         }
 
+        if ($this->filesystem->has($targetFile) && $this->config->skip_duplicates) {
+            return $targetFile;
+        }
+
         $this->filesystem->copy(
             str_replace($this->workingDir, '', $file->getPathname()),
             $targetFile


### PR DESCRIPTION
## Problem

if you want to use two packages with same namespace (e.g. `illuminate/support` and `illuminate/collections`) which shares similar files, Mozart will throw an "File already exists" error.

## Solution

While moving file check if it already exists. In case mentioned above it is only `LICENSE.md` file, so it doesn't matter from which package it will be. Also added flag to config to allow enabling this behavior (disabled by default).
