### PR TITLE
prevent prepending classmap prefix multiple times

### DIFF
--- a/src/Replace/ClassmapReplacer.php
+++ b/src/Replace/ClassmapReplacer.php
@@ -48,6 +48,11 @@ class ClassmapReplacer extends BaseReplacer
                     return $matches[0] ;
                 }
 
+                // Prevent prepending prefix multiple times.
+                if (substr($matches[1], 0, strlen($this->classmap_prefix)) === $this->classmap_prefix) {
+                    return $matches[0];
+                }
+
                 // The prepended class name.
                 $replace = $this->classmap_prefix . $matches[1];
                 $this->saveReplacedClass($matches[1], $replace);


### PR DESCRIPTION
On my project some weird bug happened with prepending same prefix multiple times to classmaps. I couldn't locate where is the problem, so I have prepared "dirty" fix.

![obraz](https://user-images.githubusercontent.com/2657856/156367287-7ff24614-363b-4c5a-a775-9e134f0b80ae.png)
