### PR TITLE
Devcontainer implementation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "dockerComposeFile": "../docker-compose.yml",
+    "service": "builder",
+    "workspaceFolder": "/mozart/",
+    "shutdownAction": "stopCompose"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM composer:2.7.7
-
 FROM php:8.3.9-cli-alpine AS base
 
 FROM base as builder
@@ -7,11 +6,15 @@ RUN apk update && apk add git
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 COPY ./composer.json /mozart/
 WORKDIR /mozart/
+RUN composer install
+
+FROM builder as packager
+RUN rm -rf vendor
 RUN composer install --no-dev -o
 
 FROM base AS application
 RUN mkdir project
 WORKDIR /project/
-COPY --from=builder /mozart/ /mozart/
+COPY --from=packager /mozart/ /mozart/
 COPY ./bin/ /mozart/bin/
 COPY ./src/ /mozart/src/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.4'
+services:
+  builder:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
+    volumes:
+      - .:/mozart/
+    command: /bin/sh -c "while sleep 1000; do :; done"


### PR DESCRIPTION
Implements a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) to the repository which is based on the actual container as provided by this repository for using the Mozart project. Added a separate stage in the build of the container, which is being used as the devcontainer, but uses the exact same versions and configuration of the required packages, as it is simply a step/stage before the final stage of the Dockerfile is being reached. This is enforced via the included `docker-compose.yml` file, which [specifies the `builder` stage](https://github.com/coenjacobs/mozart/pull/148/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R7) of the image, instead of using the full `application` stage (which no longer includes development requirements).