### PR TITLE
fix: prevent incorrect replacement of property names and variables

### DIFF
--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -149,6 +149,14 @@ class Replacer
                             if (preg_match('/(include|require)/', $matches[0])) {
                                 return $matches[0];
                             }
+                            // Don't replace if this looks like property access (->)
+                            if (substr($matches[1], -1) === '-' && $matches[2] === '>') {
+                                return $matches[0];
+                            }
+                            // Don't replace if this looks like a variable name ($)
+                            if ($matches[2] === '$') {
+                                return $matches[0];
+                            }
                             return $matches[1] . $matches[2] . $replacement . $matches[3];
                         },
                         $contents

--- a/tests/ReplacerTest.php
+++ b/tests/ReplacerTest.php
@@ -178,5 +178,110 @@ class ReplacerTest extends TestCase
         // Should complete without error
         $this->assertTrue(true);
     }
+
+    /**
+     * Test that replaceParentClassesInDirectory does not replace property access
+     *
+     * This tests the fix for the bug where $this->names was incorrectly replaced
+     * with $this->Prefix_names when a class named "names" existed.
+     *
+     * @test
+     * @see https://github.com/coenjacobs/mozart/issues/XXX
+     */
+    public function it_does_not_replace_property_access(): void
+    {
+        // Create test directory structure
+        $testDir = $this->testDir . DIRECTORY_SEPARATOR . 'deps' . DIRECTORY_SEPARATOR . 'Test';
+        mkdir($testDir, 0777, true);
+
+        // Create a file with property access that should NOT be replaced
+        $testFile = $testDir . DIRECTORY_SEPARATOR . 'TestClass.php';
+        $originalContent = <<<'PHP'
+<?php
+class TestClass {
+    private $names = [];
+
+    public function getName() {
+        return $this->names['en'];
+    }
+
+    public function setNames($names) {
+        $this->names = $names;
+    }
+}
+PHP;
+        file_put_contents($testFile, $originalContent);
+
+        // Create a replacer and manually set replaced classes using reflection
+        $replacer = new Replacer($this->config);
+
+        // Use reflection to add 'names' to the replacedClasses array
+        $reflection = new \ReflectionClass($replacer);
+        $property = $reflection->getProperty('replacedClasses');
+        $property->setAccessible(true);
+        $property->setValue($replacer, ['names' => 'Test_names']);
+
+        // Run the replacement
+        $replacer->replaceParentClassesInDirectory($testDir);
+
+        // Read the result
+        $resultContent = file_get_contents($testFile);
+
+        // Property access ($this->names) should NOT be replaced
+        $this->assertStringContainsString('$this->names', $resultContent);
+        $this->assertStringNotContainsString('$this->Test_names', $resultContent);
+
+        // Variable names ($names) should NOT be replaced
+        $this->assertStringContainsString('setNames($names)', $resultContent);
+        $this->assertStringNotContainsString('setNames($Test_names)', $resultContent);
+    }
+
+    /**
+     * Test that replaceParentClassesInDirectory still replaces actual class usages
+     *
+     * @test
+     */
+    public function it_replaces_actual_class_usages(): void
+    {
+        // Create test directory structure
+        $testDir = $this->testDir . DIRECTORY_SEPARATOR . 'deps' . DIRECTORY_SEPARATOR . 'Test';
+        mkdir($testDir, 0777, true);
+
+        // Create a file with actual class usage that SHOULD be replaced
+        $testFile = $testDir . DIRECTORY_SEPARATOR . 'Consumer.php';
+        $originalContent = <<<'PHP'
+<?php
+class Consumer {
+    public function create() {
+        return new MyClass();
+    }
+
+    public function call() {
+        return MyClass::staticMethod();
+    }
+}
+PHP;
+        file_put_contents($testFile, $originalContent);
+
+        // Create a replacer and manually set replaced classes
+        $replacer = new Replacer($this->config);
+
+        $reflection = new \ReflectionClass($replacer);
+        $property = $reflection->getProperty('replacedClasses');
+        $property->setAccessible(true);
+        $property->setValue($replacer, ['MyClass' => 'Test_MyClass']);
+
+        // Run the replacement
+        $replacer->replaceParentClassesInDirectory($testDir);
+
+        // Read the result
+        $resultContent = file_get_contents($testFile);
+
+        // Class instantiation (new MyClass) SHOULD be replaced
+        $this->assertStringContainsString('new Test_MyClass()', $resultContent);
+
+        // Static method call (MyClass::) SHOULD be replaced
+        $this->assertStringContainsString('Test_MyClass::staticMethod()', $resultContent);
+    }
 }
 


### PR DESCRIPTION
## Summary

The `replaceParentClassesInDirectory` method was too aggressive with its regex replacement, incorrectly replacing property access and variable names when a class with a matching name existed.

### Problem

For example, if a class named `names` was prefixed to `Test_names`, the method would also incorrectly replace:
- `$this->names` (property access) → `$this->Test_names`
- `$names` (variable) → `$Test_names`

This caused issues when using libraries like GeoIP2 which have properties named `names`, where the property access would be incorrectly replaced.

### Solution

This fix adds checks to skip replacement when:
1. The match looks like property access (preceded by `->`)
2. The match looks like a variable name (preceded by `$`)

### Changes

- Modified `src/Replacer.php` to add property/variable detection in the replacement callback
- Added tests in `tests/ReplacerTest.php` to verify:
  - Property access and variable names are NOT replaced
  - Actual class usages (`new`, `::`) are still correctly replaced

### Test Plan

- [x] Added unit tests for the fix
- [x] Verified PHP syntax is valid