### PR TITLE
fix: backport property name replacement fix to 0.7.x (PHP 7.3/7.4 compatible)

### DIFF
--- a/src/Replacer.php
+++ b/src/Replacer.php
@@ -151,6 +151,14 @@ class Replacer
                             if (preg_match('/(include|require)/', $matches[0], $output_array)) {
                                 return $matches[0];
                             }
+                            // Don't replace if this looks like property access (->)
+                            if (substr($matches[1], -1) === '-' && $matches[2] === '>') {
+                                return $matches[0];
+                            }
+                            // Don't replace if this looks like a variable name ($)
+                            if ($matches[2] === '$') {
+                                return $matches[0];
+                            }
                             return $matches[1] . $matches[2] . $replacement . $matches[3];
                         },
                         $contents


### PR DESCRIPTION
## Summary

This is a backport of the fix from PR #185 to the `release-0.7` branch, maintaining PHP 7.3/7.4 compatibility for users who cannot upgrade to PHP 8.1+.

### Problem

The `replaceParentClassesInDirectory` method was too aggressive with its regex replacement, incorrectly replacing property access and variable names when a class with a matching name existed.

For example, if a class named `names` was prefixed to `Test_names`, the method would also incorrectly replace:
- `$this->names` (property access) → `$this->Test_names`
- `$names` (variable) → `$Test_names`

### Solution

This fix adds checks to skip replacement when:
1. The match looks like property access (preceded by `->`)
2. The match looks like a variable name (preceded by `$`)

### Why This PR

Mozart 1.0.x requires PHP 8.1+ due to updated dependencies (Symfony 6.x, Flysystem 3.x). Many WordPress plugins need to support PHP 7.4, so having this fix available in the 0.7.x line is important.

### Request

Would you consider releasing a 0.7.2 with this fix for users who need PHP 7.3/7.4 support?