### PR TITLE
Add class_alias string argument prefixing support

### DIFF
--- a/src/Replace/Classmap/NameVisitor.php
+++ b/src/Replace/Classmap/NameVisitor.php
@@ -91,12 +91,16 @@ class NameVisitor extends NodeVisitorAbstract
      */
     protected function processExistenceCheck(FuncCall $node): ?FuncCall
     {
-        $parsed = $this->parseExistenceCheck($node);
-        if ($parsed === null || !isset($this->classMap[$parsed['value']])) {
-            return null;
+        $allParsed = $this->parseAllExistenceChecks($node);
+        $modified = false;
+
+        foreach ($allParsed as $parsed) {
+            if (isset($this->classMap[$parsed['value']])) {
+                $parsed['argNode']->value = $this->classMap[$parsed['value']] . $parsed['suffix'];
+                $modified = true;
+            }
         }
 
-        $parsed['argNode']->value = $this->classMap[$parsed['value']] . $parsed['suffix'];
-        return $node;
+        return $modified ? $node : null;
     }
 }

--- a/src/Replace/Namespace/PrefixVisitor.php
+++ b/src/Replace/Namespace/PrefixVisitor.php
@@ -313,12 +313,16 @@ class PrefixVisitor extends NodeVisitorAbstract
      */
     protected function processExistenceCheck(FuncCall $node): ?FuncCall
     {
-        $parsed = $this->parseExistenceCheck($node);
-        if ($parsed === null || !$this->shouldPrefixNamespace($parsed['value'])) {
-            return null;
+        $allParsed = $this->parseAllExistenceChecks($node);
+        $modified = false;
+
+        foreach ($allParsed as $parsed) {
+            if ($this->shouldPrefixNamespace($parsed['value'])) {
+                $parsed['argNode']->value = $this->prefix . '\\' . $parsed['value'] . $parsed['suffix'];
+                $modified = true;
+            }
         }
 
-        $parsed['argNode']->value = $this->prefix . '\\' . $parsed['value'] . $parsed['suffix'];
-        return $node;
+        return $modified ? $node : null;
     }
 }

--- a/src/Replace/Support/ExistenceCheckTrait.php
+++ b/src/Replace/Support/ExistenceCheckTrait.php
@@ -14,7 +14,8 @@ use PhpParser\Node\Scalar\String_;
  *
  * Handles functions that accept fully-qualified class, function, or constant names as string
  * arguments: function_exists(), class_exists(), interface_exists(), trait_exists(), enum_exists(),
- * constant(), defined(), method_exists(), property_exists(), is_a(), is_subclass_of(), is_callable()
+ * constant(), defined(), method_exists(), property_exists(), is_a(), is_subclass_of(),
+ * is_callable(), class_alias()
  */
 trait ExistenceCheckTrait
 {
@@ -24,50 +25,78 @@ trait ExistenceCheckTrait
      * For functions that accept Class::member strings (constant, defined, is_callable),
      * the ::member suffix is separated from the class/namespace value.
      *
+     * Returns only the first matching argument (backward compatibility).
+     *
      * @return array{argNode: String_, value: string, suffix: string}|null
      */
     protected function parseExistenceCheck(FuncCall $node): ?array
     {
-        if (!$node->name instanceof Name) {
-            return null;
-        }
-
-        $functionName = $node->name->toString();
-        $argIndex = $this->getExistenceCheckArgIndex($functionName);
-        if ($argIndex === null) {
-            return null;
-        }
-
-        if (count($node->args) <= $argIndex || !$node->args[$argIndex] instanceof Arg) {
-            return null;
-        }
-
-        $argValue = $node->args[$argIndex]->value;
-        if (!$argValue instanceof String_) {
-            return $this->parseDoubleColonConcat($functionName, $argValue);
-        }
-
-        return $this->extractValueAndSuffix($functionName, $argValue);
+        $results = $this->parseAllExistenceChecks($node);
+        return $results[0] ?? null;
     }
 
     /**
-     * Get the argument index for a known existence-check function, or null if not recognized.
+     * Parse all matching arguments from an existence-check function call.
+     *
+     * For functions like class_alias that have multiple string arguments to process,
+     * this returns one result per matching argument.
+     *
+     * @return array<int, array{argNode: String_, value: string, suffix: string}>
      */
-    private function getExistenceCheckArgIndex(string $functionName): ?int
+    protected function parseAllExistenceChecks(FuncCall $node): array
+    {
+        if (!$node->name instanceof Name) {
+            return [];
+        }
+
+        $functionName = $node->name->toString();
+        $argIndices = $this->getExistenceCheckArgIndices($functionName);
+        if ($argIndices === null) {
+            return [];
+        }
+
+        $results = [];
+        foreach ($argIndices as $argIndex) {
+            if (count($node->args) <= $argIndex || !$node->args[$argIndex] instanceof Arg) {
+                continue;
+            }
+
+            $argValue = $node->args[$argIndex]->value;
+            if (!$argValue instanceof String_) {
+                $parsed = $this->parseDoubleColonConcat($functionName, $argValue);
+                if ($parsed !== null) {
+                    $results[] = $parsed;
+                }
+                continue;
+            }
+
+            $results[] = $this->extractValueAndSuffix($functionName, $argValue);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get the argument indices for a known existence-check function, or null if not recognized.
+     *
+     * @return int[]|null
+     */
+    private function getExistenceCheckArgIndices(string $functionName): ?array
     {
         $map = [
-            'function_exists'  => 0,
-            'class_exists'     => 0,
-            'interface_exists' => 0,
-            'trait_exists'     => 0,
-            'enum_exists'      => 0,
-            'constant'         => 0,
-            'defined'          => 0,
-            'method_exists'    => 0,
-            'property_exists'  => 0,
-            'is_callable'      => 0,
-            'is_a'             => 1,
-            'is_subclass_of'   => 1,
+            'function_exists'  => [0],
+            'class_exists'     => [0],
+            'interface_exists' => [0],
+            'trait_exists'     => [0],
+            'enum_exists'      => [0],
+            'constant'         => [0],
+            'defined'          => [0],
+            'method_exists'    => [0],
+            'property_exists'  => [0],
+            'is_callable'      => [0],
+            'is_a'             => [1],
+            'is_subclass_of'   => [1],
+            'class_alias'      => [0, 1],
         ];
 
         return $map[$functionName] ?? null;

--- a/tests/Unit/Replace/Classmap/NameVisitorTest.php
+++ b/tests/Unit/Replace/Classmap/NameVisitorTest.php
@@ -509,4 +509,49 @@ class NameVisitorTest extends TestCase
 
         $this->assertStringContainsString("is_callable('Prefix_MyClass::'", $result);
     }
+
+    #[Test]
+    public function it_replaces_class_name_in_class_alias_first_argument(): void
+    {
+        $code = "class_alias('MyClass', 'Legacy_MyClass');";
+        $classMap = ['MyClass' => 'Prefix_MyClass'];
+
+        $result = $this->processCode($code, $classMap);
+
+        $this->assertStringContainsString("class_alias('Prefix_MyClass'", $result);
+    }
+
+    #[Test]
+    public function it_replaces_class_name_in_class_alias_second_argument(): void
+    {
+        $code = "class_alias('SomeClass', 'MyClass');";
+        $classMap = ['MyClass' => 'Prefix_MyClass'];
+
+        $result = $this->processCode($code, $classMap);
+
+        $this->assertStringContainsString("'Prefix_MyClass')", $result);
+    }
+
+    #[Test]
+    public function it_replaces_only_mapped_arguments_in_class_alias(): void
+    {
+        $code = "class_alias('MyClass', 'OtherClass');";
+        $classMap = ['MyClass' => 'Prefix_MyClass'];
+
+        $result = $this->processCode($code, $classMap);
+
+        $this->assertStringContainsString("class_alias('Prefix_MyClass', 'OtherClass')", $result);
+    }
+
+    #[Test]
+    public function it_does_not_replace_non_mapped_class_in_class_alias(): void
+    {
+        $code = "class_alias('UnknownClass', 'AnotherClass');";
+        $classMap = ['MyClass' => 'Prefix_MyClass'];
+
+        $result = $this->processCode($code, $classMap);
+
+        $this->assertStringContainsString("class_alias('UnknownClass', 'AnotherClass')", $result);
+        $this->assertStringNotContainsString('Prefix_', $result);
+    }
 }

--- a/tests/Unit/Replace/Namespace/PrefixVisitorTest.php
+++ b/tests/Unit/Replace/Namespace/PrefixVisitorTest.php
@@ -667,4 +667,41 @@ $check = is_callable(\'Invoker\\Invoker::\' . $method);';
 
         $this->assertStringContainsString('use const MyPlugin\\Dependencies\\Invoker\\SOME_CONSTANT as MY_CONST;', $result);
     }
+
+    #[Test]
+    public function it_prefixes_class_alias_first_argument(): void
+    {
+        $code = '<?php
+class_alias(\'Invoker\\Invoker\', \'Legacy_Invoker\');';
+        $result = $this->processCode($code, ['Invoker']);
+
+        $this->assertStringContainsString(
+            "class_alias('MyPlugin\\\\Dependencies\\\\Invoker\\\\Invoker'",
+            $result
+        );
+    }
+
+    #[Test]
+    public function it_does_not_prefix_non_target_namespace_in_class_alias(): void
+    {
+        $code = '<?php
+class_alias(\'SomeOther\\Client\', \'Legacy_Client\');';
+        $result = $this->processCode($code, ['Invoker']);
+
+        $this->assertStringContainsString("class_alias('SomeOther\\\\Client'", $result);
+        $this->assertStringNotContainsString('MyPlugin', $result);
+    }
+
+    #[Test]
+    public function it_prefixes_both_class_alias_arguments_when_both_are_namespaced(): void
+    {
+        $code = '<?php
+class_alias(\'Invoker\\Invoker\', \'Invoker\\LegacyInvoker\');';
+        $result = $this->processCode($code, ['Invoker']);
+
+        $this->assertStringContainsString(
+            "class_alias('MyPlugin\\\\Dependencies\\\\Invoker\\\\Invoker', 'MyPlugin\\\\Dependencies\\\\Invoker\\\\LegacyInvoker')",
+            $result
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `class_alias` to the existence check function map with both arguments (indices 0 and 1) processed
- Renames `getExistenceCheckArgIndex()` to `getExistenceCheckArgIndices()` returning arrays instead of single ints
- Adds `parseAllExistenceChecks()` for multi-argument support; keeps `parseExistenceCheck()` as backward-compatible wrapper
- Updates `PrefixVisitor` and `NameVisitor` to loop through all matching arguments
- Adds 7 new tests covering class_alias in both namespace and classmap contexts

Relates to #143