### PR TITLE
Document Flysystem visibility default

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,10 @@ tests/
   Support/                          # IntegrationTestCase base class, AstProcessingTestTrait
 ```
 
+## Flysystem visibility default
+
+`FilesHandler` creates its `LocalFilesystemAdapter` with `Visibility::PUBLIC`. Without this, Flysystem defaults to private visibility — directories get `0700` and files get `0600`, which breaks setups where the web server user differs from the Composer user. If the adapter construction is ever changed, the permission tests in `FilesHandlerTest` will catch the regression.
+
 ## Key dependencies
 
 | Package | Purpose |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -152,3 +152,4 @@ Several GitHub issues have dedicated regression tests to prevent recurrence:
 | #93 | `ClassmapReplacerTest` | Namespace-aware class replacement |
 | #159 | `Integration/Psr4ArrayAutoload` | PSR-4 arrays with non-existent directories |
 | #177 | `Unit/Replace/Issues/Issue177Test` + `Integration/PhpDiPackage` | Nullable type hint double-prefixing |
+| #209 | `FilesHandlerTest` | Restrictive file permissions (0700/0600) from Flysystem's default private visibility |


### PR DESCRIPTION
## Summary

- Add a section to `docs/architecture.md` explaining why `FilesHandler` explicitly sets `Visibility::PUBLIC` on the Flysystem adapter, and what breaks without it
- Add #209 to the regression test table in `docs/testing.md`

Companion to the fix in `fix/file-permissions-visibility`.