### PR TITLE
[Backport] Add docblock to NamespaceAutoloader::getFiles() to pass doc check

### DIFF
--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -57,6 +57,9 @@ abstract class NamespaceAutoloader extends AbstractAutoloader
         return '';
     }
 
+    /**
+     * @return array<string,SplFileInfo>
+     */
     public function getFiles(FilesHandler $fileHandler): array
     {
         $this->fileHandler = $fileHandler;


### PR DESCRIPTION
Backport of the docblock addition from #195

The `is_dir()` guard added directly to `release-1.0` in `e6a3bff` pushed the cognitive complexity of `getFiles()` past the doc check threshold, but since that commit was pushed without a PR, CI never caught the failure. This was already fixed on `release-1.1` in `259e340`.