### PR TITLE
[Backport] Fix override_autoload using property access on ArrayObject

### DIFF
--- a/src/PackageFinder.php
+++ b/src/PackageFinder.php
@@ -48,11 +48,8 @@ class PackageFinder
             throw new ConfigurationException("Couldn't load package based on provided slug: " . $slug);
         }
 
-        $autoloaders = null;
         $overrideAutoload = $this->config->getOverrideAutoload();
-        if ($overrideAutoload !== false && isset($overrideAutoload->$slug)) {
-            $autoloaders = $overrideAutoload->$slug;
-        }
+        $autoloaders = $overrideAutoload->getByKey($slug);
 
         $package = $this->factory->createPackage($packageDir . 'composer.json', $autoloaders);
         $package->loadDependencies($this);


### PR DESCRIPTION
Backport of #285

Replaces #298, which was incorrectly auto-closed by GitHub without its contents actually being merged.