### PR TITLE
Pass tag to github-release action for PHAR upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: meeDamian/github-release@2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.release.tag_name }}
           files: mozart.phar
           gzip: false
           allow_override: true


### PR DESCRIPTION
The `meeDamian/github-release@2.0` action requires an explicit `tag` input to identify which release to attach assets to. Without it, the PHAR upload step fails with `missing: tag`.