### PR TITLE
Fix Windows directory separator breaking PSR-4 path flattening

### DIFF
--- a/src/Composer/Autoload/NamespaceAutoloader.php
+++ b/src/Composer/Autoload/NamespaceAutoloader.php
@@ -94,7 +94,8 @@ abstract class NamespaceAutoloader extends AbstractAutoloader
         $suffix = '';
         foreach ($this->paths as $path) {
             $directoryName = $this->getPackage()->getDirectoryName();
-            if (str_contains($file->getPathname(), $directoryName . DIRECTORY_SEPARATOR . $path)) {
+            $searchPath = str_replace('/', DIRECTORY_SEPARATOR, $directoryName . DIRECTORY_SEPARATOR . $path);
+            if (str_contains($file->getPathname(), $searchPath)) {
                 $suffix = $path;
                 break;
             }

--- a/src/Config/Classmap.php
+++ b/src/Config/Classmap.php
@@ -89,7 +89,8 @@ class Classmap extends AbstractAutoloader
         $suffix = '';
         foreach ($this->paths as $path) {
             $directoryName = $this->getPackage()->getDirectoryName();
-            if (str_contains($file->getPathname(), $directoryName . DIRECTORY_SEPARATOR . $path)) {
+            $searchPath = str_replace('/', DIRECTORY_SEPARATOR, $directoryName . DIRECTORY_SEPARATOR . $path);
+            if (str_contains($file->getPathname(), $searchPath)) {
                 $suffix = $path;
                 break;
             }

--- a/src/Config/Files.php
+++ b/src/Config/Files.php
@@ -117,7 +117,7 @@ class Files extends AbstractAutoloader
         }
 
         // File is global scope - put it in classmap_directory with package name
-        $packageName = $this->getPackage()->getDirectoryName();
+        $packageName = str_replace('/', DIRECTORY_SEPARATOR, $this->getPackage()->getDirectoryName());
         return $this->fileHandler->getConfig()->getClassmapDirectory()
             . $packageName . DIRECTORY_SEPARATOR . $file->getFilename();
     }

--- a/src/Config/Mozart.php
+++ b/src/Config/Mozart.php
@@ -110,12 +110,14 @@ class Mozart
      */
     public function getDepDirectory(): string
     {
-        return trim($this->depDirectory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $dir = str_replace('/', DIRECTORY_SEPARATOR, $this->depDirectory);
+        return trim($dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }
 
     public function getClassmapDirectory(): string
     {
-        return trim($this->classmapDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $dir = str_replace('/', DIRECTORY_SEPARATOR, $this->classmapDir);
+        return trim($dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }
 
     public function getDeleteVendorDirectories(): bool

--- a/tests/Unit/Autoload/NamespaceAutoloaderTargetFileTest.php
+++ b/tests/Unit/Autoload/NamespaceAutoloaderTargetFileTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace CoenJacobs\Mozart\Tests\Unit\Autoload;
+
+use CoenJacobs\Mozart\Config\Mozart;
+use CoenJacobs\Mozart\Config\Package;
+use CoenJacobs\Mozart\Config\Psr4;
+use CoenJacobs\Mozart\FilesHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\SplFileInfo;
+
+class NamespaceAutoloaderTargetFileTest extends TestCase
+{
+    private string $testDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'mozart_autoloader_test_' . uniqid();
+        mkdir($this->testDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if (is_dir($this->testDir)) {
+            $this->removeDirectory($this->testDir);
+        }
+    }
+
+    /** @test */
+    public function it_strips_src_path_from_psr4_target_file(): void
+    {
+        // Set up directory structure: vendor/php-di/php-di/src/Attribute/Inject.php
+        $vendorDir = $this->testDir . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'php-di' . DIRECTORY_SEPARATOR . 'php-di'
+            . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Attribute';
+        mkdir($vendorDir, 0777, true);
+        file_put_contents($vendorDir . DIRECTORY_SEPARATOR . 'Inject.php', '<?php' . PHP_EOL);
+
+        $config = new Mozart();
+        $config->setDepDirectory('src/Dependencies/');
+        $config->setDepNamespace('MyPlugin\\Dependencies\\');
+        $config->setClassmapDirectory('src/Dependencies/classmap/');
+        $config->setClassmapPrefix('MyPlugin_');
+        $config->setWorkingDir($this->testDir . DIRECTORY_SEPARATOR);
+
+        $package = new Package();
+        $package->name = 'php-di/php-di';
+
+        $autoloader = new Psr4();
+        $autoloader->setPackage($package);
+        $autoloader->setNamespace('DI\\');
+        $autoloader->processConfig('src/');
+
+        $fileHandler = new FilesHandler($config);
+        $files = $autoloader->getFiles($fileHandler);
+
+        $this->assertNotEmpty($files, 'Should find files in vendor directory');
+
+        $file = reset($files);
+        $targetPath = $autoloader->getTargetFilePath($file);
+
+        // The src/ directory should be stripped — the target path should NOT contain /src/
+        $this->assertStringNotContainsString(
+            DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Attribute',
+            $targetPath,
+            'The src/ path should be stripped from the target file path'
+        );
+
+        // Should end with the namespace-based path
+        $this->assertStringEndsWith(
+            DIRECTORY_SEPARATOR . 'DI' . DIRECTORY_SEPARATOR . 'Attribute' . DIRECTORY_SEPARATOR . 'Inject.php',
+            $targetPath
+        );
+    }
+
+    /** @test */
+    public function it_handles_empty_psr4_path(): void
+    {
+        // Set up directory structure: vendor/some/package/Foo/Bar.php
+        $vendorDir = $this->testDir . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'some' . DIRECTORY_SEPARATOR . 'package'
+            . DIRECTORY_SEPARATOR . 'Foo';
+        mkdir($vendorDir, 0777, true);
+        file_put_contents($vendorDir . DIRECTORY_SEPARATOR . 'Bar.php', '<?php' . PHP_EOL);
+
+        $config = new Mozart();
+        $config->setDepDirectory('lib/Dependencies/');
+        $config->setDepNamespace('Plugin\\Deps\\');
+        $config->setClassmapDirectory('lib/Dependencies/classmap/');
+        $config->setClassmapPrefix('Plugin_');
+        $config->setWorkingDir($this->testDir . DIRECTORY_SEPARATOR);
+
+        $package = new Package();
+        $package->name = 'some/package';
+
+        $autoloader = new Psr4();
+        $autoloader->setPackage($package);
+        $autoloader->setNamespace('Some\\Namespace\\');
+        $autoloader->processConfig('');
+
+        $fileHandler = new FilesHandler($config);
+        $files = $autoloader->getFiles($fileHandler);
+
+        $this->assertNotEmpty($files, 'Should find files in vendor directory');
+
+        $file = reset($files);
+        $targetPath = $autoloader->getTargetFilePath($file);
+
+        // Vendor path components should not be in the target
+        $this->assertStringNotContainsString('vendor', $targetPath);
+        $this->assertStringNotContainsString('some' . DIRECTORY_SEPARATOR . 'package', $targetPath);
+
+        // Should contain namespace path and the file
+        $this->assertStringContainsString(
+            'Some' . DIRECTORY_SEPARATOR . 'Namespace',
+            $targetPath
+        );
+        $this->assertStringEndsWith('Bar.php', $targetPath);
+    }
+
+    /** @test */
+    public function it_strips_path_with_array_of_psr4_paths(): void
+    {
+        // Set up directory structure with two source paths
+        $srcDir = $this->testDir . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'test' . DIRECTORY_SEPARATOR . 'multi'
+            . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Core';
+        mkdir($srcDir, 0777, true);
+        file_put_contents($srcDir . DIRECTORY_SEPARATOR . 'Engine.php', '<?php' . PHP_EOL);
+
+        $libDir = $this->testDir . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'test' . DIRECTORY_SEPARATOR . 'multi'
+            . DIRECTORY_SEPARATOR . 'lib';
+        mkdir($libDir, 0777, true);
+        file_put_contents($libDir . DIRECTORY_SEPARATOR . 'Helper.php', '<?php' . PHP_EOL);
+
+        $config = new Mozart();
+        $config->setDepDirectory('deps/');
+        $config->setDepNamespace('App\\Deps\\');
+        $config->setClassmapDirectory('deps/classmap/');
+        $config->setClassmapPrefix('App_');
+        $config->setWorkingDir($this->testDir . DIRECTORY_SEPARATOR);
+
+        $package = new Package();
+        $package->name = 'test/multi';
+
+        $autoloader = new Psr4();
+        $autoloader->setPackage($package);
+        $autoloader->setNamespace('Test\\Multi\\');
+        $autoloader->processConfig(['src/', 'lib/']);
+
+        $fileHandler = new FilesHandler($config);
+        $files = $autoloader->getFiles($fileHandler);
+
+        $this->assertCount(2, $files, 'Should find files from both source paths');
+
+        foreach ($files as $file) {
+            $targetPath = $autoloader->getTargetFilePath($file);
+
+            // Neither src/ nor lib/ should remain in the target path
+            $this->assertStringNotContainsString(
+                DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Core',
+                $targetPath,
+                'The src/ path should be stripped from target: ' . $targetPath
+            );
+            $this->assertStringNotContainsString(
+                DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'Helper',
+                $targetPath,
+                'The lib/ path should be stripped from target: ' . $targetPath
+            );
+        }
+    }
+
+    /**
+     * @param string $dir
+     */
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

- Normalizes forward slashes to `DIRECTORY_SEPARATOR` in path comparisons and config getters across four files, fixing PSR-4 path flattening on Windows
- Adds unit tests for `NamespaceAutoloader::getTargetFilePath()` to verify `src/` stripping behavior

## Problem

On Windows, PSR-4 dependencies keep their source directory (e.g. `src/`) in the output path, breaking autoloading:

```
src\Dependencies\DI\src\Attribute\Inject.php   <- wrong (src/ not stripped)
src\Dependencies\DI\Attribute\Inject.php        <- correct
```

### Root cause

Config values from `composer.json` and autoloader paths use forward slashes (`/`), but `DIRECTORY_SEPARATOR` on Windows is `\` and `SplFileInfo::getPathname()` returns backslash paths. When these are mixed in `str_contains()` comparisons, suffix detection fails and the source directory is never stripped.

### Regression source

Commit `be0ba40` (Sep 19, 2024) — "Reduce Mover complexity by defering file path handling to autoloaders". The old code received `$path` as a direct parameter (always included in the vendor path to strip). The refactored code detects `$path` via `str_contains()` — and this comparison fails on Windows due to mixed separators.

## Changes

| File | Fix |
|---|---|
| `src/Config/Mozart.php` | Normalize `getDepDirectory()` and `getClassmapDirectory()` — trim with `DIRECTORY_SEPARATOR` had no effect on forward-slash config values on Windows |
| `src/Composer/Autoload/NamespaceAutoloader.php` | Normalize the search string in suffix detection before `str_contains()` |
| `src/Config/Classmap.php` | Same suffix detection fix as NamespaceAutoloader |
| `src/Config/Files.php` | Normalize package directory name in global-scope file target path |
| `tests/Unit/Autoload/NamespaceAutoloaderTargetFileTest.php` | New unit tests verifying `src/` is stripped from PSR-4 target paths |

## Test plan

- [x] All 290 tests pass (including 3 new unit tests)
- [x] phpcs, phpstan, phpmd, php-doc-check all pass
- [x] Existing integration tests (PhpDiPackage, Psr4ArrayAutoload) continue to pass
- [ ] Manual verification on Windows to confirm the fix resolves the reported issue

## Related

- Fixes #307
- Created #309 for adding a Windows CI job to catch this class of bugs in the future