### PR TITLE
Add test coverage for enum handling in classmap mode

### DIFF
--- a/tests/Unit/Replace/GlobalScope/DeclarationVisitorTest.php
+++ b/tests/Unit/Replace/GlobalScope/DeclarationVisitorTest.php
@@ -228,6 +228,16 @@ PHP;
     }
 
     #[Test]
+    public function it_renames_enum_implementing_interface(): void
+    {
+        $code = 'enum Status implements HasLabel { case Active; }';
+
+        $result = $this->processCode($code, 'Mozart_');
+
+        $this->assertStringContainsString('enum Mozart_Status implements HasLabel', $result['code']);
+    }
+
+    #[Test]
     public function it_does_not_rename_enum_inside_namespace_block(): void
     {
         $code = 'namespace MyNamespace; enum Status { case Active; }';

--- a/tests/Unit/Replace/GlobalScope/GlobalScopeReplacerTest.php
+++ b/tests/Unit/Replace/GlobalScope/GlobalScopeReplacerTest.php
@@ -196,6 +196,34 @@ class GlobalScopeReplacerTest extends TestCase
         $this->assertEquals('Mozart_My_Custom_Class', $replaced['My_Custom_Class']);
     }
 
+    #[Test]
+    public function it_replaces_enum_declarations(): void
+    {
+        $contents = '<?php enum Status { case Active; }';
+        $replacer = new GlobalScopeReplacer('Mozart_');
+        $result = $replacer->replace($contents);
+        $this->assertStringContainsString('enum Mozart_Status', $result);
+    }
+
+    #[Test]
+    public function it_replaces_backed_enum_declarations(): void
+    {
+        $contents = '<?php enum Color: string { case Red = \'red\'; }';
+        $replacer = new GlobalScopeReplacer('Mozart_');
+        $result = $replacer->replace($contents);
+        $this->assertStringContainsString('enum Mozart_Color', $result);
+    }
+
+    #[Test]
+    public function it_stores_replaced_enum_names(): void
+    {
+        $contents = '<?php enum Status { case Active; }';
+        $replacer = new GlobalScopeReplacer('Mozart_');
+        $replacer->replace($contents);
+        $this->assertArrayHasKey('Status', $replacer->getReplacedClasses());
+        $this->assertEquals('Mozart_Status', $replacer->getReplacedClasses()['Status']);
+    }
+
     // --- Constant prefixing tests ---
 
     #[Test]

--- a/tests/Unit/Replace/GlobalScope/NameVisitorTest.php
+++ b/tests/Unit/Replace/GlobalScope/NameVisitorTest.php
@@ -410,6 +410,17 @@ class NameVisitorTest extends TestCase
     }
 
     #[Test]
+    public function it_replaces_enum_name_in_case_access(): void
+    {
+        $code = '$val = MyEnum::Active;';
+        $classMap = ['MyEnum' => 'Prefix_MyEnum'];
+
+        $result = $this->processCode($code, $classMap);
+
+        $this->assertStringContainsString('Prefix_MyEnum::Active', $result);
+    }
+
+    #[Test]
     public function it_replaces_class_name_in_method_exists(): void
     {
         $code = "if (method_exists('MyClass', 'myMethod')) {}";


### PR DESCRIPTION
Closes #268.

The implementation for enum declaration handling was already shipped in #289 / #290, which added `Enum_` to `DeclarationVisitor`'s instanceof check. This PR rounds that up with the missing test coverage:

- **`GlobalScopeReplacerTest`** — 3 orchestrator-level tests: basic enum prefixing, backed enum (`enum Color: string`), and enum tracking in `getReplacedClasses()`
- **`DeclarationVisitorTest`** — 1 test for `enum Status implements HasLabel` (declaration prefixed, implements reference left for Pass 2)
- **`NameVisitorTest`** — 1 test for enum case access (`MyEnum::Active` → `Prefix_MyEnum::Active`)

No source code changes, tests only.