### PR TITLE
Fix case-insensitive symbol lookups

### DIFF
--- a/src/PhpSymbols/BuiltInSymbols.php
+++ b/src/PhpSymbols/BuiltInSymbols.php
@@ -14,7 +14,17 @@ class BuiltInSymbols implements BuiltInSymbolsInterface
     public function __construct(?string $dataFile = null)
     {
         $dataFile = $dataFile ?? __DIR__ . '/data/php-symbols.php';
-        $this->symbols = require $dataFile;
+        $symbols = require $dataFile;
+
+        // Lowercase keys for case-insensitive lookups (PHP symbols are case-insensitive
+        // except constants). Constants stay as-is.
+        $symbols['classes'] = array_change_key_case($symbols['classes'], CASE_LOWER);
+        $symbols['interfaces'] = array_change_key_case($symbols['interfaces'], CASE_LOWER);
+        $symbols['traits'] = array_change_key_case($symbols['traits'], CASE_LOWER);
+        $symbols['enums'] = array_change_key_case($symbols['enums'], CASE_LOWER);
+        $symbols['functions'] = array_change_key_case($symbols['functions'], CASE_LOWER);
+
+        $this->symbols = $symbols;
     }
 
     /**
@@ -22,7 +32,7 @@ class BuiltInSymbols implements BuiltInSymbolsInterface
      */
     public function isBuiltInClass(string $name): bool
     {
-        return isset($this->symbols['classes'][$name]);
+        return isset($this->symbols['classes'][strtolower($name)]);
     }
 
     /**
@@ -30,7 +40,7 @@ class BuiltInSymbols implements BuiltInSymbolsInterface
      */
     public function isBuiltInInterface(string $name): bool
     {
-        return isset($this->symbols['interfaces'][$name]);
+        return isset($this->symbols['interfaces'][strtolower($name)]);
     }
 
     /**
@@ -38,7 +48,7 @@ class BuiltInSymbols implements BuiltInSymbolsInterface
      */
     public function isBuiltInTrait(string $name): bool
     {
-        return isset($this->symbols['traits'][$name]);
+        return isset($this->symbols['traits'][strtolower($name)]);
     }
 
     /**
@@ -46,7 +56,7 @@ class BuiltInSymbols implements BuiltInSymbolsInterface
      */
     public function isBuiltInEnum(string $name): bool
     {
-        return isset($this->symbols['enums'][$name]);
+        return isset($this->symbols['enums'][strtolower($name)]);
     }
 
     /**
@@ -65,7 +75,7 @@ class BuiltInSymbols implements BuiltInSymbolsInterface
      */
     public function isBuiltInFunction(string $name): bool
     {
-        return isset($this->symbols['functions'][$name]);
+        return isset($this->symbols['functions'][strtolower($name)]);
     }
 
     /**

--- a/src/Replace/GlobalScope/DeclarationVisitor.php
+++ b/src/Replace/GlobalScope/DeclarationVisitor.php
@@ -215,7 +215,7 @@ class DeclarationVisitor extends NodeVisitorAbstract
      */
     protected function processDefineCall(FuncCall $node): ?FuncCall
     {
-        if (!$node->name instanceof Name || $node->name->toString() !== 'define') {
+        if (!$node->name instanceof Name || strtolower($node->name->toString()) !== 'define') {
             return null;
         }
 

--- a/src/Replace/GlobalScope/NameVisitor.php
+++ b/src/Replace/GlobalScope/NameVisitor.php
@@ -35,6 +35,13 @@ class NameVisitor extends NodeVisitorAbstract
     protected array $classMap;
 
     /**
+     * Lowercase-keyed version of classMap for case-insensitive lookups.
+     *
+     * @var array<string,string>
+     */
+    protected array $classMapLower;
+
+    /**
      * Map of original constant names to their prefixed versions.
      *
      * @var array<string,string>
@@ -49,6 +56,13 @@ class NameVisitor extends NodeVisitorAbstract
     protected array $functionMap;
 
     /**
+     * Lowercase-keyed version of functionMap for case-insensitive lookups.
+     *
+     * @var array<string,string>
+     */
+    protected array $functionMapLower;
+
+    /**
      * @param array<string,string> $classMap Map of original => prefixed class names
      * @param array<string,string> $constantMap Map of original => prefixed constant names
      * @param array<string,string> $functionMap Map of original => prefixed function names
@@ -56,8 +70,10 @@ class NameVisitor extends NodeVisitorAbstract
     public function __construct(array $classMap, array $constantMap = [], array $functionMap = [])
     {
         $this->classMap = $classMap;
+        $this->classMapLower = array_change_key_case($classMap, CASE_LOWER);
         $this->constantMap = $constantMap;
         $this->functionMap = $functionMap;
+        $this->functionMapLower = array_change_key_case($functionMap, CASE_LOWER);
     }
 
     /**
@@ -93,13 +109,14 @@ class NameVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        // Check if this name is in our classmap
-        if (!isset($this->classMap[$nameStr])) {
+        // Check if this name is in our classmap (case-insensitive)
+        $nameLower = strtolower($nameStr);
+        if (!isset($this->classMapLower[$nameLower])) {
             return null;
         }
 
         // Replace with the prefixed version
-        $prefixedName = $this->classMap[$nameStr];
+        $prefixedName = $this->classMapLower[$nameLower];
 
         if ($node->isFullyQualified()) {
             return new Name\FullyQualified($prefixedName);
@@ -159,8 +176,9 @@ class NameVisitor extends NodeVisitorAbstract
         if ($node->name instanceof Name) {
             $nameStr = $node->name->toString();
 
-            if (!str_contains($nameStr, '\\') && isset($this->functionMap[$nameStr])) {
-                $prefixedName = $this->functionMap[$nameStr];
+            $nameLower = strtolower($nameStr);
+            if (!str_contains($nameStr, '\\') && isset($this->functionMapLower[$nameLower])) {
+                $prefixedName = $this->functionMapLower[$nameLower];
 
                 $node->name = $node->name->isFullyQualified()
                     ? new Name\FullyQualified($prefixedName)
@@ -186,15 +204,16 @@ class NameVisitor extends NodeVisitorAbstract
 
         foreach ($allParsed as $parsed) {
             $value = $parsed['value'];
+            $valueLower = strtolower($value);
 
-            if (isset($this->classMap[$value])) {
-                $parsed['argNode']->value = $this->classMap[$value] . $parsed['suffix'];
+            if (isset($this->classMapLower[$valueLower])) {
+                $parsed['argNode']->value = $this->classMapLower[$valueLower] . $parsed['suffix'];
                 $modified = true;
             } elseif (isset($this->constantMap[$value])) {
                 $parsed['argNode']->value = $this->constantMap[$value] . $parsed['suffix'];
                 $modified = true;
-            } elseif (isset($this->functionMap[$value])) {
-                $parsed['argNode']->value = $this->functionMap[$value] . $parsed['suffix'];
+            } elseif (isset($this->functionMapLower[$valueLower])) {
+                $parsed['argNode']->value = $this->functionMapLower[$valueLower] . $parsed['suffix'];
                 $modified = true;
             }
         }

--- a/src/Replace/Namespace/PrefixVisitor.php
+++ b/src/Replace/Namespace/PrefixVisitor.php
@@ -270,24 +270,24 @@ class PrefixVisitor extends NodeVisitorAbstract
     {
         $namespace = trim($namespace, '\\');
 
-        // Check if it already has the prefix
-        if (str_starts_with($namespace, $this->prefix . '\\')) {
+        // Check if it already has the prefix (case-insensitive)
+        if (strncasecmp($namespace, $this->prefix . '\\', strlen($this->prefix) + 1) === 0) {
             return false;
         }
 
-        // Check if it's exactly the prefix
-        if ($namespace === $this->prefix) {
+        // Check if it's exactly the prefix (case-insensitive)
+        if (strcasecmp($namespace, $this->prefix) === 0) {
             return false;
         }
 
         foreach ($this->targetNamespaces as $target) {
-            // Exact match
-            if ($namespace === $target) {
+            // Exact match (case-insensitive)
+            if (strcasecmp($namespace, $target) === 0) {
                 return true;
             }
 
-            // Starts with target namespace (sub-namespace)
-            if (str_starts_with($namespace, $target . '\\')) {
+            // Starts with target namespace (sub-namespace, case-insensitive)
+            if (strncasecmp($namespace, $target . '\\', strlen($target) + 1) === 0) {
                 return true;
             }
         }

--- a/src/Replace/Support/ExistenceCheckTrait.php
+++ b/src/Replace/Support/ExistenceCheckTrait.php
@@ -99,7 +99,7 @@ trait ExistenceCheckTrait
             'class_alias'      => [0, 1],
         ];
 
-        return $map[$functionName] ?? null;
+        return $map[strtolower($functionName)] ?? null;
     }
 
     /**
@@ -107,7 +107,7 @@ trait ExistenceCheckTrait
      */
     private function supportsDoubleColon(string $functionName): bool
     {
-        return in_array($functionName, ['constant', 'defined', 'is_callable'], true);
+        return in_array(strtolower($functionName), ['constant', 'defined', 'is_callable'], true);
     }
 
     /**

--- a/tests/Unit/PhpSymbols/BuiltInSymbolsTest.php
+++ b/tests/Unit/PhpSymbols/BuiltInSymbolsTest.php
@@ -86,6 +86,30 @@ class BuiltInSymbolsTest extends TestCase
     }
 
     #[Test]
+    public function it_recognizes_built_in_class_with_different_casing(): void
+    {
+        $this->assertTrue($this->symbols->isBuiltInClass('stdclass'));
+        $this->assertTrue($this->symbols->isBuiltInClass('STDCLASS'));
+        $this->assertTrue($this->symbols->isBuiltInClass('exception'));
+    }
+
+    #[Test]
+    public function it_recognizes_built_in_function_with_different_casing(): void
+    {
+        $this->assertTrue($this->symbols->isBuiltInFunction('STRLEN'));
+        $this->assertTrue($this->symbols->isBuiltInFunction('Array_Map'));
+        $this->assertTrue($this->symbols->isBuiltInFunction('CLASS_EXISTS'));
+    }
+
+    #[Test]
+    public function it_does_not_recognize_constant_with_different_casing(): void
+    {
+        // Constants are case-sensitive
+        $this->assertFalse($this->symbols->isBuiltInConstant('php_eol'));
+        $this->assertFalse($this->symbols->isBuiltInConstant('php_int_max'));
+    }
+
+    #[Test]
     public function it_accepts_custom_data_file_path(): void
     {
         $customFile = __DIR__ . '/fixtures/custom-symbols.php';

--- a/tests/Unit/Replace/GlobalScope/DeclarationVisitorTest.php
+++ b/tests/Unit/Replace/GlobalScope/DeclarationVisitorTest.php
@@ -507,4 +507,14 @@ PHP;
         $this->assertStringNotContainsString('mozart_', $result['code']);
         $this->assertEmpty($result['visitor']->getReplacedFunctions());
     }
+
+    #[Test]
+    public function it_recognizes_uppercase_define_call(): void
+    {
+        $code = "DEFINE('MY_CONST', 'value');";
+
+        $result = $this->processCodeWithConstantPrefix($code, 'MOZART_');
+
+        $this->assertStringContainsString("DEFINE('MOZART_MY_CONST'", $result['code']);
+    }
 }

--- a/tests/Unit/Replace/GlobalScope/NameVisitorTest.php
+++ b/tests/Unit/Replace/GlobalScope/NameVisitorTest.php
@@ -709,4 +709,51 @@ class NameVisitorTest extends TestCase
         $this->assertStringContainsString('function_exists(', $result);
         $this->assertStringNotContainsString('mozart_function_exists', $result);
     }
+
+    // --- Case-insensitive lookup tests ---
+
+    #[Test]
+    public function it_replaces_class_reference_with_different_casing(): void
+    {
+        $code = 'function test(myclass $var) {}';
+        $classMap = ['MyClass' => 'Prefix_MyClass'];
+
+        $result = $this->processCode($code, $classMap);
+
+        $this->assertStringContainsString('Prefix_MyClass $var', $result);
+    }
+
+    #[Test]
+    public function it_replaces_function_call_with_different_casing(): void
+    {
+        $code = 'MY_HELPER();';
+        $functionMap = ['my_helper' => 'mozart_my_helper'];
+
+        $result = $this->processCodeWithFunctionMap($code, $functionMap);
+
+        $this->assertStringContainsString('mozart_my_helper()', $result);
+    }
+
+    #[Test]
+    public function it_replaces_class_exists_with_mixed_case_function_name(): void
+    {
+        $code = "if (Class_Exists('MyClass')) {}";
+        $classMap = ['MyClass' => 'Prefix_MyClass'];
+
+        $result = $this->processCode($code, $classMap);
+
+        $this->assertStringContainsString("Class_Exists('Prefix_MyClass')", $result);
+    }
+
+    #[Test]
+    public function it_does_not_replace_constant_with_different_casing(): void
+    {
+        $code = '$val = my_const;';
+        $constantMap = ['MY_CONST' => 'MOZART_MY_CONST'];
+
+        $result = $this->processCodeWithConstantMap($code, $constantMap);
+
+        // Constants are case-sensitive — different casing should NOT match
+        $this->assertStringNotContainsString('MOZART_MY_CONST', $result);
+    }
 }

--- a/tests/Unit/Replace/Namespace/PrefixVisitorTest.php
+++ b/tests/Unit/Replace/Namespace/PrefixVisitorTest.php
@@ -704,4 +704,37 @@ class_alias(\'Invoker\\Invoker\', \'Invoker\\LegacyInvoker\');';
             $result
         );
     }
+
+    // --- Case-insensitive namespace matching tests ---
+
+    #[Test]
+    public function it_prefixes_namespace_with_different_casing(): void
+    {
+        $code = '<?php namespace invoker;';
+        $result = $this->processCode($code, ['Invoker']);
+
+        $this->assertStringContainsString('namespace MyPlugin\\Dependencies\\invoker;', $result);
+    }
+
+    #[Test]
+    public function it_prefixes_use_statement_with_different_casing(): void
+    {
+        $code = '<?php use INVOKER\\Invoker;';
+        $result = $this->processCode($code, ['Invoker']);
+
+        $this->assertStringContainsString('use MyPlugin\\Dependencies\\INVOKER\\Invoker;', $result);
+    }
+
+    #[Test]
+    public function it_recognizes_class_exists_with_mixed_case_function_name(): void
+    {
+        $code = '<?php
+if (Class_Exists(\'Invoker\\Invoker\')) {}';
+        $result = $this->processCode($code, ['Invoker']);
+
+        $this->assertStringContainsString(
+            "Class_Exists('MyPlugin\\\\Dependencies\\\\Invoker\\\\Invoker')",
+            $result
+        );
+    }
 }


### PR DESCRIPTION
- PHP symbol names (classes, functions, namespaces) are case-insensitive, but Mozart used case-sensitive lookups throughout the replacement pipeline
- Fixes all map lookups and string comparisons to be case-insensitive using `strtolower()`, `strcasecmp()`, and `array_change_key_case()`
- Constants remain case-sensitive, matching PHP semantics

Closes #232 