### PR TITLE
Fix delete_vendor_directories setter name mismatch

### DIFF
--- a/src/Config/Mozart.php
+++ b/src/Config/Mozart.php
@@ -23,7 +23,7 @@ class Mozart
     public array $excludedPackages = [];
 
     public OverrideAutoload $overrideAutoload;
-    public bool $deleteVendorDir = true;
+    public bool $deleteVendorDirs = true;
 
     public string $workingDir = '';
 
@@ -81,9 +81,9 @@ class Mozart
         $this->overrideAutoload = new OverrideAutoload($object);
     }
 
-    public function setDeleteVendorDir(bool $deleteVendorDir): void
+    public function setDeleteVendorDirectories(bool $deleteVendorDirs): void
     {
-        $this->deleteVendorDir = $deleteVendorDir;
+        $this->deleteVendorDirs = $deleteVendorDirs;
     }
 
     public function isValidMozartConfig(): bool
@@ -122,7 +122,7 @@ class Mozart
 
     public function getDeleteVendorDirectories(): bool
     {
-        return $this->deleteVendorDir;
+        return $this->deleteVendorDirs;
     }
 
     public function getDependencyNamespace(): string

--- a/tests/Unit/Config/ConfigMapperTest.php
+++ b/tests/Unit/Config/ConfigMapperTest.php
@@ -38,4 +38,33 @@ class ConfigMapperTest extends TestCase
         $this->assertInstanceOf(OverrideAutoload::class, $package->getExtra()->getMozart()->getOverrideAutoload());
         $this->assertCount(4, $package->autoload->getAutoloaders());
     }
+
+    /** @test */
+    public function it_respects_explicit_delete_vendor_directories_false(): void
+    {
+        $config = new Mozart();
+        $result = $config->loadFromString(json_encode([
+            'dep_namespace' => 'Test\\Dependencies',
+            'dep_directory' => '/deps/',
+            'classmap_directory' => '/classes/',
+            'classmap_prefix' => 'Test_',
+            'delete_vendor_directories' => false,
+        ]));
+
+        $this->assertFalse($result->getDeleteVendorDirectories());
+    }
+
+    /** @test */
+    public function it_defaults_delete_vendor_directories_to_true(): void
+    {
+        $config = new Mozart();
+        $result = $config->loadFromString(json_encode([
+            'dep_namespace' => 'Test\\Dependencies',
+            'dep_directory' => '/deps/',
+            'classmap_directory' => '/classes/',
+            'classmap_prefix' => 'Test_',
+        ]));
+
+        $this->assertTrue($result->getDeleteVendorDirectories());
+    }
 }


### PR DESCRIPTION
Forward-port of #320.

- Rename property `$deleteVendorDir` → `$deleteVendorDirectories`, setter `setDeleteVendorDir()` → `setDeleteVendorDirectories()`, and update the getter body to match
- JsonMapper translates `delete_vendor_directories` to `setDeleteVendorDirectories()` — the abbreviated setter was silently skipped, leaving the default `true` regardless of user config
- Add regression tests proving explicit `false` is respected and the default remains `true`

Fixes #317