### PR TITLE
Fix delete_vendor_directories setter name mismatch and config output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ Mozart Configuration (resolved from composer.json)
   constant_prefix:        (not set)
   functions_prefix:       (not set)
   generate_autoloader:    true                        (default)
-  delete_vendor_dirs:     true                        (default)
+  delete_vendor_directories: true                     (default)
   packages:               (all require dependencies)
   excluded_packages:      (none)
 ```

--- a/src/Commands/Config.php
+++ b/src/Commands/Config.php
@@ -52,7 +52,7 @@ class Config
             'classmap_directory'       => $config->classmapDir,
             'classmap_prefix'          => $config->classmapPrefix,
             'generate_autoloader'      => $config->generateAutoloader,
-            'delete_vendor_directories' => $config->deleteVendorDir,
+            'delete_vendor_directories' => $config->deleteVendorDirs,
         ];
     }
 

--- a/src/Config/Mozart.php
+++ b/src/Config/Mozart.php
@@ -27,7 +27,7 @@ class Mozart
 
     public OverrideAutoload $overrideAutoload;
     public bool $generateAutoloader = true;
-    public bool $deleteVendorDir = true;
+    public bool $deleteVendorDirs = true;
 
     public string $workingDir = '';
 
@@ -109,9 +109,12 @@ class Mozart
         $this->generateAutoloader = $generateAutoloader;
     }
 
-    public function setDeleteVendorDir(bool $deleteVendorDir): void
+    /**
+     * Enable or disable deletion of vendor directories after processing.
+     */
+    public function setDeleteVendorDirectories(bool $deleteVendorDirs): void
     {
-        $this->deleteVendorDir = $deleteVendorDir;
+        $this->deleteVendorDirs = $deleteVendorDirs;
     }
 
     public function isValidMozartConfig(): bool
@@ -249,7 +252,7 @@ class Mozart
 
     public function getDeleteVendorDirectories(): bool
     {
-        return $this->deleteVendorDir;
+        return $this->deleteVendorDirs;
     }
 
     public function getDependencyNamespace(): string

--- a/src/Console/Commands/Config.php
+++ b/src/Console/Commands/Config.php
@@ -69,7 +69,7 @@ class Config extends Command
         $autoloaderSource = $sources['generate_autoloader'];
         $this->printBoolSetting($output, 'generate_autoloader', $config->generateAutoloader, $autoloaderSource);
         $deleteSource = $sources['delete_vendor_directories'];
-        $this->printBoolSetting($output, 'delete_vendor_dirs', $config->deleteVendorDir, $deleteSource);
+        $this->printBoolSetting($output, 'delete_vendor_directories', $config->deleteVendorDirs, $deleteSource);
         $this->printListSetting($output, 'packages', $config->getPackages(), '(all require dependencies)');
         $this->printListSetting($output, 'excluded_packages', $config->getExcludedPackages(), '(none)');
     }

--- a/tests/Integration/PreserveVendorDirectories/PreserveVendorDirectoriesTest.php
+++ b/tests/Integration/PreserveVendorDirectories/PreserveVendorDirectoriesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CoenJacobs\Mozart\Tests\Integration\PreserveVendorDirectories;
+
+use CoenJacobs\Mozart\Tests\Support\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class PreserveVendorDirectoriesTest extends IntegrationTestCase
+{
+    /**
+     * Verifies that setting `delete_vendor_directories` to `false` preserves
+     * the original vendor directories after Mozart has moved and rewritten the
+     * package files. The dependencies should exist in both the target directory
+     * (rewritten) and the original vendor directory (untouched).
+     */
+    #[Test]
+    public function it_preserves_vendor_directories_when_configured(): void
+    {
+        $this->copyFixtures();
+        $this->runComposerInstall();
+        $result = $this->runMozart();
+
+        $this->assertEquals(0, $result);
+
+        // Dependencies are moved and rewritten into the target directory
+        $this->assertDirectoryExists($this->testsWorkingDir . '/src/dependencies/Pimple');
+
+        // Original vendor directories are preserved because delete_vendor_directories is false
+        $this->assertDirectoryExists($this->testsWorkingDir . '/vendor/pimple/pimple');
+    }
+}

--- a/tests/Integration/PreserveVendorDirectories/composer.json
+++ b/tests/Integration/PreserveVendorDirectories/composer.json
@@ -1,0 +1,23 @@
+{
+    "require": {
+        "pimple/pimple": "^3.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Mozart\\TestProject\\": "src/"
+        }
+    },
+    "extra": {
+        "mozart": {
+            "dep_namespace": "Mozart\\TestProject\\Dependencies",
+            "dep_directory": "/src/dependencies",
+            "classmap_directory": "/classes/",
+            "classmap_prefix": "MozartDependency_",
+            "packages": [
+                "pimple/pimple"
+            ],
+            "override_autoload": {},
+            "delete_vendor_directories": false
+        }
+    }
+}

--- a/tests/Unit/Config/ConfigMapperTest.php
+++ b/tests/Unit/Config/ConfigMapperTest.php
@@ -259,6 +259,62 @@ class ConfigMapperTest extends TestCase
         $this->assertNotContains('dep_directory', $missing);
     }
 
+    #[Test]
+    public function it_respects_explicit_delete_vendor_directories_false(): void
+    {
+        $config = new Mozart();
+        $result = $config->loadFromString(json_encode([
+            'dep_namespace' => 'Test\\Dependencies',
+            'dep_directory' => '/deps/',
+            'classmap_directory' => '/classes/',
+            'classmap_prefix' => 'Test_',
+            'delete_vendor_directories' => false,
+        ]));
+
+        $this->assertFalse($result->getDeleteVendorDirectories());
+    }
+
+    #[Test]
+    public function it_defaults_delete_vendor_directories_to_true(): void
+    {
+        $config = new Mozart();
+        $result = $config->loadFromString(json_encode([
+            'dep_namespace' => 'Test\\Dependencies',
+            'dep_directory' => '/deps/',
+            'classmap_directory' => '/classes/',
+            'classmap_prefix' => 'Test_',
+        ]));
+
+        $this->assertTrue($result->getDeleteVendorDirectories());
+    }
+
+    #[Test]
+    public function it_preserves_explicit_delete_vendor_directories_false_after_defaults(): void
+    {
+        $package = $this->createPackageWithPsr4('MyPlugin\\');
+
+        $config = new Mozart();
+        $result = $config->loadFromString(json_encode([
+            'delete_vendor_directories' => false,
+        ]));
+        $result->applyDefaults($package);
+
+        $this->assertFalse($result->getDeleteVendorDirectories());
+        $this->assertTrue($result->isValidMozartConfig());
+    }
+
+    #[Test]
+    public function it_defaults_delete_vendor_directories_to_true_after_defaults(): void
+    {
+        $package = $this->createPackageWithPsr4('MyPlugin\\');
+
+        $config = new Mozart();
+        $result = $config->loadFromString(json_encode(new \stdClass()));
+        $result->applyDefaults($package);
+
+        $this->assertTrue($result->getDeleteVendorDirectories());
+    }
+
     /**
      * Create a Package with a PSR-4 autoloader for testing.
      */


### PR DESCRIPTION
Forward-port of #320.

- Rename setter `setDeleteVendorDir()` → `setDeleteVendorDirectories()` so JsonMapper can find it when mapping the `delete_vendor_directories` JSON key
- Property keeps the abbreviated `$deleteVendorDirs` name to satisfy phpmd's variable length rule, matching the existing `$classmapDir` / `setClassmapDirectory()` pattern
- Fix `mozart config` console output displaying the key as `delete_vendor_dirs` instead of `delete_vendor_directories`
- Fix the same typo in `docs/configuration.md`
- Add unit tests proving explicit `false` survives both config mapping and `applyDefaults()`
- Add integration test (`PreserveVendorDirectories`) verifying vendor directories are actually preserved end-to-end when the setting is `false`

Fixes #317