### PR TITLE
Fix symlinks in vendor packages causing UnableToListContents failure

### DIFF
--- a/src/FilesHandler.php
+++ b/src/FilesHandler.php
@@ -4,6 +4,7 @@ namespace CoenJacobs\Mozart;
 
 use CoenJacobs\Mozart\Config\Mozart;
 use CoenJacobs\Mozart\Exceptions\FileOperationException;
+use FilesystemIterator;
 use Iterator;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\FilesystemOperationFailed;
@@ -88,9 +89,25 @@ class FilesHandler
         }
     }
 
+    /**
+     * Check whether the given path is an empty directory.
+     *
+     * Uses native FilesystemIterator instead of Flysystem's listContents()
+     * because Flysystem throws SymbolicLinkEncountered when it encounters
+     * symlinks in the directory tree. Symlinks are valid filesystem entries
+     * and should not cause a failure here.
+     */
     public function isDirectoryEmpty(string $path): bool
     {
-        return count($this->filesystem->listContents($path, true)->toArray()) === 0;
+        $fullPath = $this->config->getWorkingDir() . $path;
+
+        if (!is_dir($fullPath)) {
+            return true;
+        }
+
+        $iterator = new FilesystemIterator($fullPath);
+
+        return !$iterator->valid();
     }
 
     public function copyFile(string $origin, string $destination): void

--- a/tests/Unit/FilesHandlerTest.php
+++ b/tests/Unit/FilesHandlerTest.php
@@ -49,7 +49,13 @@ class FilesHandlerTest extends TestCase
         $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             $path = $dir . DIRECTORY_SEPARATOR . $file;
-            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
         }
         rmdir($dir);
     }
@@ -127,6 +133,42 @@ class FilesHandlerTest extends TestCase
 
         $this->assertTrue($handler->isDirectoryEmpty($emptyDir));
         $this->assertFalse($handler->isDirectoryEmpty($nonEmptyDir));
+    }
+
+    #[Test]
+    public function it_does_not_throw_when_directory_contains_symlink(): void
+    {
+        $dirPath = 'dir_with_symlink';
+        $targetFile = 'target.txt';
+
+        file_put_contents($this->testDir . DIRECTORY_SEPARATOR . $targetFile, 'content');
+        mkdir($this->testDir . DIRECTORY_SEPARATOR . $dirPath, 0777, true);
+        symlink(
+            $this->testDir . DIRECTORY_SEPARATOR . $targetFile,
+            $this->testDir . DIRECTORY_SEPARATOR . $dirPath . DIRECTORY_SEPARATOR . 'link.txt'
+        );
+
+        $handler = new FilesHandler($this->config);
+
+        $this->assertFalse($handler->isDirectoryEmpty($dirPath));
+    }
+
+    #[Test]
+    public function it_treats_directory_with_only_symlinks_as_non_empty(): void
+    {
+        $dirPath = 'dir_with_only_symlink';
+        $targetFile = 'outside_target.txt';
+
+        file_put_contents($this->testDir . DIRECTORY_SEPARATOR . $targetFile, 'content');
+        mkdir($this->testDir . DIRECTORY_SEPARATOR . $dirPath, 0777, true);
+        symlink(
+            $this->testDir . DIRECTORY_SEPARATOR . $targetFile,
+            $this->testDir . DIRECTORY_SEPARATOR . $dirPath . DIRECTORY_SEPARATOR . 'CLAUDE.md'
+        );
+
+        $handler = new FilesHandler($this->config);
+
+        $this->assertFalse($handler->isDirectoryEmpty($dirPath));
     }
 
     #[Test]


### PR DESCRIPTION
- Replace Flysystem's `listContents()` with native `FilesystemIterator` in `isDirectoryEmpty()` to avoid `SymbolicLinkEncountered` exceptions when vendor packages contain symbolic links
- Add regression tests verifying symlinks in directories don't cause failures and are correctly treated as non-empty
- Fix test teardown helper to unlink symlinks without following them into target directories

Fixes #371