### PR TITLE
Forward: Fix #337: Add config validation warnings to mozart config command

### DIFF
--- a/src/Commands/Config.php
+++ b/src/Commands/Config.php
@@ -26,7 +26,7 @@ class Config
      * Load the Mozart configuration, apply defaults, and return the resolved
      * config alongside source annotations for each setting.
      *
-     * @return array{config: Mozart, sources: array<string, string>}
+     * @return array{config: Mozart, sources: array<string, string>, warnings: string[]}
      */
     public function execute(): array
     {
@@ -43,7 +43,12 @@ class Config
         (new ConfigDefaultsResolver())->apply($config, $package);
         $sources = $this->buildSources($snapshot, $config, $package);
 
-        return ['config' => $config, 'sources' => $sources];
+        $warnings = [];
+        if (! $config->isValidMozartConfig()) {
+            $warnings = $config->getMissingConfigFields();
+        }
+
+        return ['config' => $config, 'sources' => $sources, 'warnings' => $warnings];
     }
 
     /**

--- a/src/Console/Commands/Config.php
+++ b/src/Console/Commands/Config.php
@@ -45,9 +45,15 @@ class Config extends Command
 
         $this->printAllSettings($output, $result['config'], $result['sources']);
 
+        if (!empty($result['warnings'])) {
+            $output->writeln('');
+            $output->writeln('<warning>⚠ Missing required fields: ' . implode(', ', $result['warnings']) . '</warning>');
+            $output->writeln('<warning>  mozart compose will fail until these are configured.</warning>');
+        }
+
         $output->writeln('');
 
-        return 0;
+        return empty($result['warnings']) ? 0 : 1;
     }
 
     /**

--- a/src/Console/Commands/Config.php
+++ b/src/Console/Commands/Config.php
@@ -47,7 +47,8 @@ class Config extends Command
 
         if (!empty($result['warnings'])) {
             $output->writeln('');
-            $output->writeln('<warning>⚠ Missing required fields: ' . implode(', ', $result['warnings']) . '</warning>');
+            $fields = implode(', ', $result['warnings']);
+            $output->writeln('<warning>⚠ Missing required fields: ' . $fields . '</warning>');
             $output->writeln('<warning>  mozart compose will fail until these are configured.</warning>');
         }
 

--- a/tests/Unit/Commands/ConfigTest.php
+++ b/tests/Unit/Commands/ConfigTest.php
@@ -364,4 +364,69 @@ class ConfigTest extends TestCase
         $sources = $result['sources'];
         $this->assertStringContainsString('inferred from package name', $sources['dep_namespace']);
     }
+
+    #[Test]
+    public function it_returns_empty_warnings_for_valid_config(): void
+    {
+        $composerJson = [
+            'name' => 'test/project',
+            'autoload' => [
+                'psr-4' => [
+                    'TestProject\\' => 'src/',
+                ],
+            ],
+            'extra' => [
+                'mozart' => new \stdClass(),
+            ],
+        ];
+
+        file_put_contents(
+            $this->testDir . DIRECTORY_SEPARATOR . 'composer.json',
+            json_encode($composerJson)
+        );
+
+        $command = new Config($this->testDir);
+        $result = $command->execute();
+
+        $this->assertEmpty($result['warnings']);
+    }
+
+    #[Test]
+    public function it_returns_warnings_for_missing_required_fields(): void
+    {
+        $composerJson = [
+            'require' => [],
+        ];
+
+        file_put_contents(
+            $this->testDir . DIRECTORY_SEPARATOR . 'composer.json',
+            json_encode($composerJson)
+        );
+
+        $command = new Config($this->testDir);
+        $result = $command->execute();
+
+        $this->assertNotEmpty($result['warnings']);
+        $this->assertContains('dep_namespace', $result['warnings']);
+        $this->assertContains('classmap_prefix', $result['warnings']);
+    }
+
+    #[Test]
+    public function it_returns_warnings_only_for_actually_missing_fields(): void
+    {
+        $composerJson = [
+            'name' => 'test/project',
+            'require' => [],
+        ];
+
+        file_put_contents(
+            $this->testDir . DIRECTORY_SEPARATOR . 'composer.json',
+            json_encode($composerJson)
+        );
+
+        $command = new Config($this->testDir);
+        $result = $command->execute();
+
+        $this->assertEmpty($result['warnings']);
+    }
 }


### PR DESCRIPTION
Forward port of #375