### PR TITLE
fix: Fix issue with alias qualified names

### DIFF
--- a/src/Replace/Namespace/PrefixVisitor.php
+++ b/src/Replace/Namespace/PrefixVisitor.php
@@ -214,7 +214,37 @@ class PrefixVisitor extends NodeVisitorAbstract
             return true;
         }
 
+        if ($this->isAliasQualifiedName($node)) {
+            return true;
+        }
+
         return $this->isUnqualifiedNameInPrefixedNamespace($node);
+    }
+
+    /**
+     * Check if node is a qualified name whose first part is a tracked alias.
+     *
+     * Names like P\Create (where P is aliased to GuzzleHttp\Promise) or
+     * Psr7\Utils (where Psr7 is aliased to GuzzleHttp\Psr7) resolve through
+     * their alias. Since the use statement is already being prefixed, the
+     * alias-based reference will resolve correctly without modification.
+     * Expanding them to the full prefixed path without making them fully
+     * qualified would cause PHP to resolve them relative to the current
+     * namespace, doubling the prefix.
+     */
+    protected function isAliasQualifiedName(Name $node): bool
+    {
+        if ($node->isFullyQualified()) {
+            return false;
+        }
+
+        $nameStr = $node->toString();
+        if (!str_contains($nameStr, '\\')) {
+            return false;
+        }
+
+        $firstPart = explode('\\', $nameStr, 2)[0];
+        return isset($this->aliases[$firstPart]);
     }
 
     /**

--- a/tests/Integration/AliasQualifiedNamespace/AliasQualifiedNamespaceTest.php
+++ b/tests/Integration/AliasQualifiedNamespace/AliasQualifiedNamespaceTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CoenJacobs\Mozart\Tests\Integration\AliasQualifiedNamespace;
+
+use CoenJacobs\Mozart\Tests\Support\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Integration tests for guzzlehttp/guzzle package processing.
+ *
+ * Guzzle and its dependencies share the GuzzleHttp namespace prefix:
+ * - guzzlehttp/guzzle: GuzzleHttp\
+ * - guzzlehttp/psr7: GuzzleHttp\Psr7\
+ * - guzzlehttp/promises: GuzzleHttp\Promise\
+ *
+ * Because the Replacer scans dep_directory/GuzzleHttp/ recursively for
+ * the parent package, sub-package files (Psr7, Promise) are processed
+ * by the parent autoloader first, then again by their own autoloader.
+ * This can cause a recurring (double) prefix replacement where alias-
+ * qualified names like P\Create or Psr7\Utils are expanded to the full
+ * prefixed path without being made fully qualified, so PHP resolves
+ * them relative to the current namespace — doubling the path.
+ */
+class AliasQualifiedNamespaceTest extends IntegrationTestCase
+{
+    /**
+     * Verifies that Mozart successfully processes the guzzlehttp/guzzle package.
+     */
+    #[Test]
+    public function it_processes_guzzle_package_successfully(): void
+    {
+        $this->copyFixtures();
+        $this->runComposerInstall();
+        $result = $this->runMozart();
+
+        $this->assertEquals(0, $result);
+
+        $this->assertDirectoryExists($this->testsWorkingDir . '/src/dependencies/GuzzleHttp');
+    }
+
+    /**
+     * Verifies that alias-qualified names are not expanded into non-fully-qualified
+     * prefixed paths, which would cause PHP to resolve them relative to the current
+     * namespace — effectively doubling the namespace prefix.
+     *
+     * Original Guzzle code uses patterns like:
+     *   use GuzzleHttp\Promise as P;
+     *   return P\Create::promiseFor(...);
+     *
+     * After Mozart, the use statement is correctly prefixed. But if P\Create is
+     * expanded to Mozart\TestProject\Dependencies\GuzzleHttp\Promise\Create (without
+     * leading backslash), PHP resolves it relative to the current namespace
+     * Mozart\TestProject\Dependencies\GuzzleHttp, producing:
+     *   Mozart\TestProject\Dependencies\GuzzleHttp\Mozart\TestProject\Dependencies\GuzzleHttp\Promise\Create
+     *
+     * This is the "recurring replacement" bug.
+     */
+    #[Test]
+    public function it_does_not_produce_recurring_replacement_in_client(): void
+    {
+        $this->copyFixtures();
+        $this->runComposerInstall();
+        $result = $this->runMozart();
+
+        $this->assertEquals(0, $result);
+
+        $clientPath = $this->testsWorkingDir . '/src/dependencies/GuzzleHttp/Client.php';
+        $this->assertFileExists($clientPath);
+
+        $content = file_get_contents($clientPath);
+
+        // The file is in namespace Mozart\TestProject\Dependencies\GuzzleHttp.
+        // Any inline reference to Mozart\TestProject\Dependencies\GuzzleHttp\Promise\Create
+        // WITHOUT a leading backslash would be resolved by PHP as:
+        //   CurrentNamespace + Reference = doubled path
+        //
+        // The reference should either stay as the alias (P\Create) or be
+        // fully qualified (\Mozart\TestProject\Dependencies\...).
+        $this->assertDoesNotMatchRegularExpression(
+            '/[^\\\\]Mozart\\\\TestProject\\\\Dependencies\\\\GuzzleHttp\\\\Promise\\\\Create::/',
+            $content,
+            'Client.php contains a non-fully-qualified prefixed reference to Promise\Create, '
+            . 'which PHP would resolve relative to the current namespace, doubling the path'
+        );
+    }
+
+    /**
+     * Verifies that relative qualified names (like Psr7\Utils) in StreamHandler
+     * are not expanded into non-fully-qualified prefixed paths.
+     *
+     * StreamHandler.php uses patterns like:
+     *   Psr7\Utils::streamFor($stream)
+     *   new Psr7\Response(...)
+     *   new Psr7\LazyOpenStream(...)
+     *
+     * These relative names resolve correctly through the current namespace.
+     * Expanding them to the full prefixed path without a leading backslash
+     * would cause the same recurring replacement as in Client.php.
+     */
+    #[Test]
+    public function it_does_not_produce_recurring_replacement_in_stream_handler(): void
+    {
+        $this->copyFixtures();
+        $this->runComposerInstall();
+        $result = $this->runMozart();
+
+        $this->assertEquals(0, $result);
+
+        $handlerPath = $this->testsWorkingDir . '/src/dependencies/GuzzleHttp/Handler/StreamHandler.php';
+        $this->assertFileExists($handlerPath);
+
+        $content = file_get_contents($handlerPath);
+
+        // Inline references should not be non-fully-qualified prefixed paths
+        $this->assertDoesNotMatchRegularExpression(
+            '/[^\\\\]Mozart\\\\TestProject\\\\Dependencies\\\\GuzzleHttp\\\\Psr7\\\\Utils::/',
+            $content,
+            'StreamHandler.php contains a non-fully-qualified prefixed reference to Psr7\Utils, '
+            . 'which PHP would resolve relative to the current namespace, doubling the path'
+        );
+    }
+
+    /**
+     * Broad check: no PHP file in the dependency output should contain a
+     * non-fully-qualified prefixed namespace reference that would cause
+     * PHP to double the path at runtime.
+     *
+     * Matches lines where the prefix appears as an inline reference without
+     * being a namespace declaration, use statement, or fully-qualified name.
+     */
+    #[Test]
+    public function it_does_not_produce_recurring_replacement_in_any_file(): void
+    {
+        $this->copyFixtures();
+        $this->runComposerInstall();
+        $result = $this->runMozart();
+
+        $this->assertEquals(0, $result);
+
+        $dependencyDir = $this->testsWorkingDir . '/src/dependencies/GuzzleHttp';
+        $this->assertDirectoryExists($dependencyDir);
+
+        $phpFiles = $this->findPhpFiles($dependencyDir);
+        $this->assertNotEmpty($phpFiles, 'Should find PHP files in the dependency directory');
+
+        $prefix = 'Mozart\\TestProject\\Dependencies\\';
+        $failedFiles = [];
+
+        foreach ($phpFiles as $filePath) {
+            $content = file_get_contents($filePath);
+            $lines = explode("\n", $content);
+            $relativePath = str_replace($this->testsWorkingDir . '/', '', $filePath);
+
+            foreach ($lines as $lineNum => $line) {
+                $trimmed = ltrim($line);
+
+                // Skip namespace declarations and use statements
+                if (str_starts_with($trimmed, 'namespace ') || str_starts_with($trimmed, 'use ')) {
+                    continue;
+                }
+
+                // Skip comment-only lines
+                if (str_starts_with($trimmed, '*') || str_starts_with($trimmed, '//') || str_starts_with($trimmed, '/*')) {
+                    continue;
+                }
+
+                // Find non-fully-qualified prefixed references in code lines.
+                // A fully-qualified reference starts with \ before the prefix.
+                // A non-qualified inline reference would have a non-backslash
+                // character (or start of line) before the prefix.
+                // Exclude string literals (e.g., function_exists('...')) since those
+                // correctly use the full namespace as a string value.
+                $pattern = '/(?<![\\\\a-zA-Z])' . preg_quote($prefix, '/') . 'GuzzleHttp\\\\/';
+                $stringPattern = "/['\"]" . preg_quote($prefix, '/') . "/";
+                if (preg_match($pattern, $line) && !preg_match($stringPattern, $line)) {
+                    $failedFiles[] = sprintf('%s:%d: %s', $relativePath, $lineNum + 1, trim($line));
+                }
+            }
+        }
+
+        $this->assertEmpty(
+            $failedFiles,
+            "Found non-fully-qualified prefixed references that would cause recurring replacement at runtime:\n"
+            . implode("\n", array_slice($failedFiles, 0, 20))
+        );
+    }
+
+    /**
+     * Find all PHP files recursively in a directory.
+     *
+     * @return array<string>
+     */
+    private function findPhpFiles(string $directory): array
+    {
+        $files = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && str_ends_with($file->getFilename(), '.php')) {
+                $files[] = $file->getRealPath();
+            }
+        }
+
+        return $files;
+    }
+}

--- a/tests/Integration/AliasQualifiedNamespace/composer.json
+++ b/tests/Integration/AliasQualifiedNamespace/composer.json
@@ -1,0 +1,24 @@
+{
+    "require": {
+        "guzzlehttp/guzzle": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Mozart\\TestProject\\": "src/"
+        }
+    },
+    "extra": {
+        "mozart": {
+            "dep_namespace": "Mozart\\TestProject\\Dependencies",
+            "dep_directory": "/src/dependencies",
+            "classmap_directory": "/classes/",
+            "classmap_prefix": "MozartDependency_",
+            "packages": [
+                "guzzlehttp/guzzle"
+            ],
+            "excluded_packages": [],
+            "override_autoload": {},
+            "delete_vendor_directories": true
+        }
+    }
+}


### PR DESCRIPTION
In Nextcloud's notification app the last autoupdate to mozart 1.2.1 (we still had 1.0.6 before) broke again :sweat_smile: 
```
Internal Server Error
Class "OCA\Notifications\Vendor\GuzzleHttp\OCA\Notifications\Vendor\GuzzleHttp\Promise\Create" not found in file '…/apps/notifications/lib/Vendor/GuzzleHttp/Pool.php' line 50
```

I used AI to create a failing test for it and then asked it to create a solution as well. The PR is the outcome.

I patched my local vendor-bin directory with the outcome.
## Original
https://github.com/guzzle/guzzle/blob/7.10/src/Pool.php#L54

## Before (v1.2.1)
```php
        } else {
            $opts = [];
        }
        $iterable = OCA\Notifications\Vendor\GuzzleHttp\Promise\Create::iterFor($requests);
        $requests = static function () use ($iterable, $client, $opts) {
            foreach ($iterable as $key => $rfn) {
                if ($rfn instanceof RequestInterface) {
```
## After (this PR)
```php
        } else {
            $opts = [];
        }
        $iterable = P\Create::iterFor($requests);
        $requests = static function () use ($iterable, $client, $opts) {
            foreach ($iterable as $key => $rfn) {
                if ($rfn instanceof RequestInterface) {
```

And the request works again

## AI summary

### Root cause

When packages share a namespace prefix (e.g., `guzzlehttp/guzzle` uses `GuzzleHttp\` and `guzzlehttp/psr7` uses `GuzzleHttp\Psr7\`), the `Replacer` scans `dep_directory/GuzzleHttp/` recursively for the parent package, picking up sub-package files too. When processing these files, the `PrefixVisitor` encounters alias-qualified names like `P\Create` (where `P` is aliased to `GuzzleHttp\Promise`) or `Psr7\Utils` (aliased to `GuzzleHttp\Psr7`). It resolved the alias, found the target namespace matched, and created a prefixed Name node — but since the original wasn't fully qualified, the result wasn't either. PHP then resolved the non-fully-qualified `Mozart\TestProject\Dependencies\GuzzleHttp\Promise\Create` relative to the current namespace `Mozart\TestProject\Dependencies\GuzzleHttp`, doubling the path.

### Fix

Added `isAliasQualifiedName()` to `PrefixVisitor` (src/Replace/Namespace/PrefixVisitor.php:229-252), called from `shouldSkipName()`. When a qualified name's first part is a tracked alias (from a use statement), the name is skipped — the use statement is already being prefixed, so the alias-based reference resolves correctly without modification.

### Test

Added `tests/Integration/GuzzlePackage/` (renamed after I understood the problem) with 4 tests that install `guzzlehttp/guzzle`, run Mozart, and verify:
1. Processing completes successfully
2. `Client.php` has no non-fully-qualified prefixed references (alias `P\Create`)
3. `StreamHandler.php` has no non-fully-qualified prefixed references (alias `Psr7\Utils`)
4. No file in the output contains the recurring replacement pattern
