### PR TITLE
test: add alias-qualified namespace regression

### DIFF
--- a/tests/Unit/Replace/Namespace/PrefixVisitorTest.php
+++ b/tests/Unit/Replace/Namespace/PrefixVisitorTest.php
@@ -735,6 +735,30 @@ $check = is_callable(\'Invoker\\Invoker::\' . $method);';
     }
 
     #[Test]
+    public function it_does_not_expand_alias_qualified_names(): void
+    {
+        $code = '<?php
+namespace GuzzleHttp;
+
+use GuzzleHttp\\Promise as P;
+
+class Pool {
+    public function create(iterable $requests) {
+        return P\\Create::iterFor($requests);
+    }
+}';
+        $result = $this->processCode($code, ['GuzzleHttp']);
+
+        $this->assertStringContainsString('namespace MyPlugin\\Dependencies\\GuzzleHttp;', $result);
+        $this->assertStringContainsString('use MyPlugin\\Dependencies\\GuzzleHttp\\Promise as P;', $result);
+        $this->assertStringContainsString('return P\\Create::iterFor($requests);', $result);
+        $this->assertStringNotContainsString(
+            'MyPlugin\\Dependencies\\GuzzleHttp\\Promise\\Create::iterFor',
+            $result
+        );
+    }
+
+    #[Test]
     public function it_prefixes_class_alias_first_argument(): void
     {
         $code = '<?php


### PR DESCRIPTION
- add a focused `PrefixVisitor` regression test for the alias-qualified case fixed in #380
- verify `use ... as` imports are prefixed while `P\\Create` remains alias-qualified