### PR TITLE
Fix: Throw explicit exception when namespace inference fails

### DIFF
--- a/src/Commands/Config.php
+++ b/src/Commands/Config.php
@@ -6,6 +6,7 @@ use CoenJacobs\Mozart\Config\ConfigDefaultsResolver;
 use CoenJacobs\Mozart\Config\Mozart;
 use CoenJacobs\Mozart\Config\Package;
 use CoenJacobs\Mozart\Config\Psr4;
+use CoenJacobs\Mozart\Exceptions\ConfigurationException;
 use CoenJacobs\Mozart\PackageFactory;
 
 class Config
@@ -40,12 +41,18 @@ class Config
         $this->raw = $this->extractRawMozart($composerFile);
 
         $snapshot = $this->snapshot($config);
-        (new ConfigDefaultsResolver())->apply($config, $package);
+        $warnings = [];
+
+        try {
+            (new ConfigDefaultsResolver())->apply($config, $package);
+        } catch (ConfigurationException $e) {
+            $warnings[] = $e->getMessage();
+        }
+
         $sources = $this->buildSources($snapshot, $config, $package);
 
-        $warnings = [];
         if (! $config->isValidMozartConfig()) {
-            $warnings = $config->getMissingConfigFields();
+            $warnings = array_merge($warnings, $config->getMissingConfigFields());
         }
 
         return ['config' => $config, 'sources' => $sources, 'warnings' => $warnings];
@@ -194,7 +201,7 @@ class Config
     private function inferNamespaceSource(Package $package, string $resolved): string
     {
         if (empty($resolved)) {
-            return '(not set)';
+            return '(could not be inferred)';
         }
 
         foreach ($package->getAutoloaders() as $autoloader) {

--- a/src/Config/ConfigDefaultsResolver.php
+++ b/src/Config/ConfigDefaultsResolver.php
@@ -23,6 +23,20 @@ class ConfigDefaultsResolver
      */
     public function apply(Mozart $config, Package $package): void
     {
+        $this->applyDirectoryDefaults($config);
+
+        $depNamespaceWasEmpty = empty($config->depNamespace);
+        $rootNamespace = $this->inferRootNamespace($package);
+
+        $this->applyNamespaceDefaults($config, $rootNamespace);
+        $this->applyPrefixDefaults($config, $depNamespaceWasEmpty, $rootNamespace);
+    }
+
+    /**
+     * Apply directory-related defaults.
+     */
+    private function applyDirectoryDefaults(Mozart $config): void
+    {
         if (empty($config->depDirectory)) {
             $config->depDirectory = 'vendor-prefixed/';
         }
@@ -30,15 +44,20 @@ class ConfigDefaultsResolver
         if (empty($config->classmapDir)) {
             $config->classmapDir = $config->depDirectory;
         }
+    }
 
-        $depNamespaceWasEmpty = empty($config->depNamespace);
-        $rootNamespace = $this->inferRootNamespace($package);
-
-        if ($depNamespaceWasEmpty && !empty($rootNamespace)) {
-            $config->depNamespace = $rootNamespace . '\\Dependencies';
+    /**
+     * Apply namespace defaults and validate inference succeeded.
+     *
+     * @throws ConfigurationException When namespace cannot be inferred.
+     */
+    private function applyNamespaceDefaults(Mozart $config, string $rootNamespace): void
+    {
+        if (!empty($config->depNamespace)) {
+            return;
         }
 
-        if ($depNamespaceWasEmpty && empty($config->depNamespace)) {
+        if (empty($rootNamespace)) {
             throw new ConfigurationException(
                 'Could not automatically determine dep_namespace. ' .
                 'Mozart tried to infer it from: ' .
@@ -48,6 +67,14 @@ class ConfigDefaultsResolver
             );
         }
 
+        $config->depNamespace = $rootNamespace . '\\Dependencies';
+    }
+
+    /**
+     * Apply prefix-related defaults.
+     */
+    private function applyPrefixDefaults(Mozart $config, bool $depNamespaceWasEmpty, string $rootNamespace): void
+    {
         if (empty($config->classmapPrefix)) {
             $prefixSource = $depNamespaceWasEmpty ? $rootNamespace : $config->depNamespace;
             $config->classmapPrefix = $this->namespaceToPrefixString($prefixSource);

--- a/src/Config/ConfigDefaultsResolver.php
+++ b/src/Config/ConfigDefaultsResolver.php
@@ -2,6 +2,8 @@
 
 namespace CoenJacobs\Mozart\Config;
 
+use CoenJacobs\Mozart\Exceptions\ConfigurationException;
+
 /**
  * Fill empty Mozart configuration properties with sensible defaults.
  *
@@ -34,6 +36,16 @@ class ConfigDefaultsResolver
 
         if ($depNamespaceWasEmpty && !empty($rootNamespace)) {
             $config->depNamespace = $rootNamespace . '\\Dependencies';
+        }
+
+        if ($depNamespaceWasEmpty && empty($config->depNamespace)) {
+            throw new ConfigurationException(
+                'Could not automatically determine dep_namespace. ' .
+                'Mozart tried to infer it from: ' .
+                '(1) the PSR-4 autoload namespace in your composer.json, or ' .
+                '(2) your package name (vendor/package format). ' .
+                'Please explicitly set "extra.mozart.dep_namespace" in your composer.json.'
+            );
         }
 
         if (empty($config->classmapPrefix)) {

--- a/src/Console/Commands/Config.php
+++ b/src/Console/Commands/Config.php
@@ -47,8 +47,10 @@ class Config extends Command
 
         if (!empty($result['warnings'])) {
             $output->writeln('');
-            $fields = implode(', ', $result['warnings']);
-            $output->writeln('<warning>⚠ Missing required fields: ' . $fields . '</warning>');
+            foreach ($result['warnings'] as $warning) {
+                $output->writeln('<warning>⚠ ' . $warning . '</warning>');
+            }
+
             $output->writeln('<warning>  mozart compose will fail until these are configured.</warning>');
         }
 

--- a/tests/Unit/Commands/ComposeTest.php
+++ b/tests/Unit/Commands/ComposeTest.php
@@ -129,7 +129,7 @@ class ComposeTest extends TestCase
         $compose = new Compose($this->testDir);
 
         $this->expectException(ConfigurationException::class);
-        $this->expectExceptionMessage('Could not determine');
+        $this->expectExceptionMessage('Could not automatically determine dep_namespace');
 
         $compose->execute();
     }

--- a/tests/Unit/Commands/ConfigTest.php
+++ b/tests/Unit/Commands/ConfigTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CoenJacobs\Mozart\Tests\Unit\Commands;
 
 use CoenJacobs\Mozart\Commands\Config;
-use CoenJacobs\Mozart\Exceptions\ConfigurationException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -407,8 +406,16 @@ class ConfigTest extends TestCase
         $result = $command->execute();
 
         $this->assertNotEmpty($result['warnings']);
+        $this->assertContains(
+            'Could not automatically determine dep_namespace. Mozart tried to infer it from: ' .
+            '(1) the PSR-4 autoload namespace in your composer.json, or ' .
+            '(2) your package name (vendor/package format). ' .
+            'Please explicitly set "extra.mozart.dep_namespace" in your composer.json.',
+            $result['warnings']
+        );
         $this->assertContains('dep_namespace', $result['warnings']);
         $this->assertContains('classmap_prefix', $result['warnings']);
+        $this->assertSame('(could not be inferred)', $result['sources']['dep_namespace']);
     }
 
     #[Test]

--- a/tests/Unit/Config/ConfigMapperTest.php
+++ b/tests/Unit/Config/ConfigMapperTest.php
@@ -10,6 +10,7 @@ use CoenJacobs\Mozart\Config\Mozart;
 use CoenJacobs\Mozart\Config\OverrideAutoload;
 use CoenJacobs\Mozart\Config\Package;
 use CoenJacobs\Mozart\PackageFactory;
+use CoenJacobs\Mozart\Exceptions\ConfigurationException;
 use CoenJacobs\Mozart\PackageFinder;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -128,18 +129,16 @@ class ConfigMapperTest extends TestCase
     }
 
     #[Test]
-    public function it_fails_validation_with_no_psr4_and_no_name(): void
+    public function it_throws_configuration_exception_when_namespace_cannot_be_inferred(): void
     {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage("Could not automatically determine dep_namespace");
+
         $package = new Package();
-        $package->name = '';
+        $package->name = "";
 
         $result = $this->loader->fromString(json_encode(new \stdClass()), Mozart::class);
         $this->defaults->apply($result, $package);
-
-        $this->assertFalse($result->isValidMozartConfig());
-        $this->assertSame('', $result->depNamespace);
-        $this->assertContains('dep_namespace', $result->getMissingConfigFields());
-        $this->assertContains('classmap_prefix', $result->getMissingConfigFields());
     }
 
     #[Test]


### PR DESCRIPTION
Closes #329

Throws  instead of failing silently when  cannot be inferred from PSR-4 autoload or package name.