### PR TITLE
Fix issue 332: add deleteFile() to FilesHandler

### DIFF
--- a/src/Autoload/AutoloaderGenerator.php
+++ b/src/Autoload/AutoloaderGenerator.php
@@ -142,7 +142,7 @@ class AutoloaderGenerator
         $autoloadFile = $this->config->getDepDirectory() . 'autoload.php';
         $absolutePath = $this->config->getWorkingDir() . $autoloadFile;
         if (file_exists($absolutePath)) {
-            unlink($absolutePath);
+            $this->files->deleteFile($autoloadFile);
         }
     }
 

--- a/src/FilesHandler.php
+++ b/src/FilesHandler.php
@@ -90,6 +90,18 @@ class FilesHandler
     }
 
     /**
+     * Delete a single file.
+     */
+    public function deleteFile(string $path): void
+    {
+        try {
+            $this->filesystem->delete($path);
+        } catch (FilesystemOperationFailed $e) {
+            throw new FileOperationException("Failed to delete file: {$path}. " . $e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
      * Check whether the given path is an empty directory.
      *
      * Uses native FilesystemIterator instead of Flysystem's listContents()

--- a/tests/Unit/FilesHandlerTest.php
+++ b/tests/Unit/FilesHandlerTest.php
@@ -11,6 +11,7 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
 use League\Flysystem\UnableToDeleteDirectory;
+use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToWriteFile;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -390,6 +391,33 @@ class FilesHandlerTest extends TestCase
         $this->expectExceptionMessage('Failed to delete directory: test_dir');
 
         $handler->deleteDirectory('test_dir');
+    }
+
+    #[Test]
+    public function it_can_delete_file(): void
+    {
+        $filePath = 'test_file.txt';
+        file_put_contents($this->testDir . DIRECTORY_SEPARATOR . $filePath, 'content');
+
+        $handler = new FilesHandler($this->config);
+        $handler->deleteFile($filePath);
+
+        $this->assertFileDoesNotExist($this->testDir . DIRECTORY_SEPARATOR . $filePath);
+    }
+
+    #[Test]
+    public function it_throws_exception_when_deleting_file_fails(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('delete')
+            ->willThrowException(UnableToDeleteFile::atLocation('test.txt', 'Permission denied'));
+
+        $handler = new FilesHandler($this->config, $filesystem);
+
+        $this->expectException(FileOperationException::class);
+        $this->expectExceptionMessage('Failed to delete file: test.txt');
+
+        $handler->deleteFile('test.txt');
     }
 }
 


### PR DESCRIPTION
Fixes #332

`AutoloaderGenerator::cleanPreviousAutoloader()` was using a bare `unlink()` call to delete the previous `autoload.php` file, bypassing the `FilesHandler` abstraction. This meant a permissions failure would emit a PHP warning instead of throwing a typed `FileOperationException`.

**Changes:**
- Add `deleteFile()` method to `FilesHandler` wrapping `Flysystem::delete()`
- Update `AutoloaderGenerator::cleanPreviousAutoloader()` to use the new method
- Add unit tests for successful deletion and exception handling