### PR TITLE
Fix issue 339: attach zero-config Mozart to package

### DIFF
--- a/src/Config/Extra.php
+++ b/src/Config/Extra.php
@@ -10,4 +10,9 @@ class Extra
     {
         return $this->mozart;
     }
+
+    public function setMozart(?Mozart $mozart): void
+    {
+        $this->mozart = $mozart;
+    }
 }

--- a/src/PackageFactory.php
+++ b/src/PackageFactory.php
@@ -3,6 +3,7 @@
 namespace CoenJacobs\Mozart;
 
 use CoenJacobs\Mozart\Config\ConfigLoader;
+use CoenJacobs\Mozart\Config\Extra;
 use CoenJacobs\Mozart\Config\Mozart;
 use CoenJacobs\Mozart\Config\Package;
 use stdClass;
@@ -51,6 +52,10 @@ class PackageFactory
      * Return the Mozart config from the package's extra.mozart block,
      * or a fresh empty config when the block is absent. Running the
      * command is the opt-in — no extra.mozart block is required.
+     *
+     * In zero-config mode, the newly created Mozart object is attached
+     * to the package so downstream code always sees the same config
+     * instance regardless of call order.
      */
     public function resolveConfig(Package $package): Mozart
     {
@@ -60,6 +65,15 @@ class PackageFactory
             return $extra->getMozart();
         }
 
-        return new Mozart();
+        $mozart = new Mozart();
+
+        if ($extra === null) {
+            $extra = new Extra();
+            $package->extra = $extra;
+        }
+
+        $extra->setMozart($mozart);
+
+        return $mozart;
     }
 }

--- a/tests/Unit/PackageFactoryTest.php
+++ b/tests/Unit/PackageFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CoenJacobs\Mozart\Tests\Unit;
 
+use CoenJacobs\Mozart\Config\Mozart;
 use CoenJacobs\Mozart\Config\Package;
 use CoenJacobs\Mozart\PackageFactory;
 use PHPUnit\Framework\Attributes\Test;
@@ -118,6 +119,71 @@ class PackageFactoryTest extends TestCase
         $package = $factory->createPackage($filePath, null);
 
         $this->assertInstanceOf(Package::class, $package);
+    }
+
+    #[Test]
+    public function it_returns_existing_mozart_when_extra_mozart_exists(): void
+    {
+        $composerJson = [
+            'name' => 'test/package',
+            'require' => [],
+            'extra' => [
+                'mozart' => [
+                    'dep_namespace' => 'Custom\\Ns',
+                    'dep_directory' => 'custom/',
+                ],
+            ],
+        ];
+        $filePath = $this->testDir . DIRECTORY_SEPARATOR . 'composer.json';
+        file_put_contents($filePath, json_encode($composerJson));
+
+        $factory = new PackageFactory();
+        $package = $factory->createPackage($filePath);
+
+        $config = $factory->resolveConfig($package);
+
+        $this->assertSame($package->getExtra()->getMozart(), $config);
+        $this->assertSame('Custom\\Ns', $config->depNamespace);
+    }
+
+    #[Test]
+    public function it_creates_and_attaches_mozart_in_zero_config_mode(): void
+    {
+        $composerJson = [
+            'name' => 'test/package',
+            'require' => [],
+        ];
+        $filePath = $this->testDir . DIRECTORY_SEPARATOR . 'composer.json';
+        file_put_contents($filePath, json_encode($composerJson));
+
+        $factory = new PackageFactory();
+        $package = $factory->createPackage($filePath);
+
+        $config = $factory->resolveConfig($package);
+
+        $this->assertInstanceOf(Mozart::class, $config);
+        $this->assertNotNull($package->getExtra());
+        $this->assertSame($config, $package->getExtra()->getMozart());
+    }
+
+    #[Test]
+    public function it_attaches_mozart_when_extra_exists_but_mozart_is_absent(): void
+    {
+        $composerJson = [
+            'name' => 'test/package',
+            'require' => [],
+            'extra' => new \stdClass(),
+        ];
+        $filePath = $this->testDir . DIRECTORY_SEPARATOR . 'composer.json';
+        file_put_contents($filePath, json_encode($composerJson));
+
+        $factory = new PackageFactory();
+        $package = $factory->createPackage($filePath);
+
+        $config = $factory->resolveConfig($package);
+
+        $this->assertInstanceOf(Mozart::class, $config);
+        $this->assertSame($config, $package->getExtra()->getMozart());
     }
 
 }


### PR DESCRIPTION
Fixes #339

In zero-config mode (no `extra.mozart` block), `PackageFactory::resolveConfig()` returned a detached `Mozart` object. This created fragile coupling between `Compose` and `PackageFactory`, as reordering `setConfig()` and `loadDependencies()` calls could cause the finder's config to be overwritten with an un-defaulted version from the package.

**Changes:**
- Add `setMozart()` to `Extra` (nullable to maintain JsonMapper compatibility)
- Update `PackageFactory::resolveConfig()` to attach the newly created `Mozart` to the package
- `Extra` is created on-the-fly when missing
- Add unit tests for the three config resolution paths