### PR TITLE
Fix issue 340: skip PSR-4 entry when no namespace deps exist

### DIFF
--- a/src/Autoload/AutoloaderGenerator.php
+++ b/src/Autoload/AutoloaderGenerator.php
@@ -50,12 +50,19 @@ class AutoloaderGenerator
     /**
      * Build the PSR-4 entries mapping the dependency namespace to dep_directory.
      *
+     * Skips emitting the entry when dep_directory is empty, which happens when
+     * no PSR-4 or PSR-0 dependencies were processed (only classmap packages).
+     *
      * @return array<string, array<string>>
      */
     protected function buildPsr4Entries(): array
     {
         $namespace = $this->config->getDependencyNamespace();
         $depDir = rtrim($this->config->getDepDirectory(), DIRECTORY_SEPARATOR . '/');
+
+        if ($this->files->isDirectoryEmpty($depDir)) {
+            return [];
+        }
 
         return [$namespace => [$depDir]];
     }

--- a/tests/Unit/Autoload/AutoloaderGeneratorTest.php
+++ b/tests/Unit/Autoload/AutoloaderGeneratorTest.php
@@ -80,6 +80,11 @@ class AutoloaderGeneratorTest extends TestCase
     {
         $this->setUpVendorComposer();
 
+        // Simulate a namespaced dependency having been moved to dep_directory
+        $nsDir = $this->testsWorkingDir . '/src/dependencies/MyPlugin/Dependencies/Foo';
+        mkdir($nsDir, 0777, true);
+        file_put_contents($nsDir . '/Bar.php', "<?php\nnamespace MyPlugin\\Dependencies\\Foo;\nclass Bar {}\n");
+
         $generator = new AutoloaderGenerator($this->config);
         $generator->generate([]);
 
@@ -88,6 +93,22 @@ class AutoloaderGeneratorTest extends TestCase
 
         $content = file_get_contents($psr4File);
         $this->assertStringContainsString('MyPlugin\\\\Dependencies\\\\', $content);
+    }
+
+    #[Test]
+    public function it_skips_psr4_mapping_when_dep_directory_is_empty(): void
+    {
+        $this->setUpVendorComposer();
+
+        // Do NOT create any files in dep_directory
+        $generator = new AutoloaderGenerator($this->config);
+        $generator->generate([]);
+
+        $psr4File = $this->testsWorkingDir . '/src/dependencies/composer/autoload_psr4.php';
+        $this->assertFileExists($psr4File);
+
+        $content = file_get_contents($psr4File);
+        $this->assertStringNotContainsString('MyPlugin\\Dependencies\\', $content);
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #340

`AutoloaderGenerator::buildPsr4Entries()` unconditionally emitted a PSR-4 autoloader prefix even when no PSR-4 or PSR-0 dependencies were processed. This caused unnecessary directory lookups for projects with only classmap packages.

**Changes:**
- Use `FilesHandler::isDirectoryEmpty()` to check `dep_directory` before emitting the PSR-4 entry
- Returns empty array when no namespaced files were moved (covers both PSR-4 and PSR-0, since both populate `dep_directory`)
- Update `it_generates_psr4_mapping` test to simulate files in `dep_directory`
- Add `it_skips_psr4_mapping_when_dep_directory_is_empty` test

No signature changes or boolean flags were added — the generator simply inspects the filesystem state after `Mover` has run.